### PR TITLE
feat: expand media-pvc from 8000Gi to 14000Gi

### DIFF
--- a/cluster/core/democratic-csi/resources/media-pvc.yaml
+++ b/cluster/core/democratic-csi/resources/media-pvc.yaml
@@ -9,5 +9,5 @@ spec:
     - ReadWriteMany
   resources:
     requests:
-      storage: 8000Gi
+      storage: 14000Gi
   storageClassName: truenas-nfs-csi


### PR DESCRIPTION
## Summary
- Expand `media-pvc` NFS quota from 8000Gi to 14000Gi to match available TrueNAS pool capacity
- The previous 8TiB quota was at 100% causing qbittorrent/sonarr/radarr to report no free space
- TrueNAS pool has ~14.4TiB total capacity so this leaves a small buffer

## Test plan
- [ ] Flux reconciles the PVC change
- [ ] democratic-csi updates the TrueNAS dataset quota to 14TB
- [ ] qbittorrent/sonarr/radarr report correct free disk space

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased media storage capacity to support additional data retention and system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->