### PR TITLE
feat(mosquitto): MQTT password auth — Phase 1 (anonymous still allowed)

### DIFF
--- a/cluster/apps/home-automation/mosquitto/externalsecret.yaml
+++ b/cluster/apps/home-automation/mosquitto/externalsecret.yaml
@@ -1,0 +1,60 @@
+---
+# MQTT broker credentials, synced from 1Password via ESO.
+#
+# 1Password item (vault: homelab):
+#   item name: "mqtt-credentials"
+#   fields (one username + one password per MQTT client):
+#     homeassistant_username  /  homeassistant_password
+#     zigbee2mqtt_username    /  zigbee2mqtt_password
+#     nodered_username        /  nodered_password
+#     philips_username        /  philips_password
+#
+# These land in the Secret "mosquitto-credentials" as env vars. The mosquitto
+# initContainer reads them and runs `mosquitto_passwd -b` to build the hashed
+# password_file. The same Secret is consumed by each client (see PR notes).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mosquitto-credentials
+  namespace: home-automation
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: mosquitto-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: HOMEASSISTANT_USERNAME
+      remoteRef:
+        key: "mqtt-credentials"
+        property: homeassistant_username
+    - secretKey: HOMEASSISTANT_PASSWORD
+      remoteRef:
+        key: "mqtt-credentials"
+        property: homeassistant_password
+    - secretKey: ZIGBEE2MQTT_USERNAME
+      remoteRef:
+        key: "mqtt-credentials"
+        property: zigbee2mqtt_username
+    - secretKey: ZIGBEE2MQTT_PASSWORD
+      remoteRef:
+        key: "mqtt-credentials"
+        property: zigbee2mqtt_password
+    - secretKey: NODERED_USERNAME
+      remoteRef:
+        key: "mqtt-credentials"
+        property: nodered_username
+    - secretKey: NODERED_PASSWORD
+      remoteRef:
+        key: "mqtt-credentials"
+        property: nodered_password
+    - secretKey: PHILIPS_USERNAME
+      remoteRef:
+        key: "mqtt-credentials"
+        property: philips_username
+    - secretKey: PHILIPS_PASSWORD
+      remoteRef:
+        key: "mqtt-credentials"
+        property: philips_password

--- a/cluster/apps/home-automation/mosquitto/values.yaml
+++ b/cluster/apps/home-automation/mosquitto/values.yaml
@@ -19,11 +19,42 @@ configMaps:
     data:
       mosquitto.conf: |
         listener 1883
+        # PHASE 1: anonymous access is still permitted so existing clients keep
+        # working while they are migrated to credentials. The password_file is
+        # also active, so authenticated clients are accepted in parallel.
+        # PHASE 2 (separate PR): flip allow_anonymous to false once every client
+        # is confirmed authenticated.
         allow_anonymous true
+        password_file /mosquitto/auth/passwd
         persistence true
         persistence_location /data
         connection_messages false
         autosave_interval 1800
+
+# initContainer builds the hashed mosquitto password_file from the plaintext
+# credentials synced by ESO (Secret: mosquitto-credentials). The file is written
+# to the shared "auth" emptyDir which the main container mounts at /mosquitto/auth.
+initContainers:
+  gen-passwd:
+    image: eclipse-mosquitto:2.0.18
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        PASSWD=/mosquitto/auth/passwd
+        # -c creates/overwrites the file for the first user, then append the rest.
+        mosquitto_passwd -b -c "$PASSWD" "$HOMEASSISTANT_USERNAME" "$HOMEASSISTANT_PASSWORD"
+        mosquitto_passwd -b    "$PASSWD" "$ZIGBEE2MQTT_USERNAME"   "$ZIGBEE2MQTT_PASSWORD"
+        mosquitto_passwd -b    "$PASSWD" "$NODERED_USERNAME"       "$NODERED_PASSWORD"
+        mosquitto_passwd -b    "$PASSWD" "$PHILIPS_USERNAME"       "$PHILIPS_PASSWORD"
+        chmod 0600 "$PASSWD"
+    envFrom:
+      - secretRef:
+          name: mosquitto-credentials
+    volumeMounts:
+      - name: auth
+        mountPath: /mosquitto/auth
 
 persistence:
   data:
@@ -35,6 +66,12 @@ persistence:
     name: mosquitto-config
     mountPath: /mosquitto/config/mosquitto.conf
     subPath: mosquitto.conf
+  # Shared emptyDir holding the generated password_file. Auto-mounted into the
+  # main container at /mosquitto/auth; the initContainer mounts it explicitly.
+  auth:
+    enabled: true
+    type: emptyDir
+    mountPath: /mosquitto/auth
 
 podSecurityContext:
   runAsUser: 568

--- a/cluster/apps/home-automation/zigbee2mqtt/values.yaml
+++ b/cluster/apps/home-automation/zigbee2mqtt/values.yaml
@@ -32,6 +32,19 @@ controllers:
           ZIGBEE2MQTT_CONFIG_MQTT_KEEPALIVE: 60
           ZIGBEE2MQTT_CONFIG_MQTT_REJECT_UNAUTHORIZED: "true"
           ZIGBEE2MQTT_CONFIG_MQTT_SERVER: mqtt://mosquitto.home-automation.svc.cluster.local
+          # MQTT credentials from the shared mosquitto-credentials Secret (ESO).
+          # Safe during PHASE 1: the broker still allows anonymous, and once the
+          # password_file exists these creds authenticate the zigbee2mqtt user.
+          ZIGBEE2MQTT_CONFIG_MQTT_USER:
+            valueFrom:
+              secretKeyRef:
+                name: mosquitto-credentials
+                key: ZIGBEE2MQTT_USERNAME
+          ZIGBEE2MQTT_CONFIG_MQTT_PASSWORD:
+            valueFrom:
+              secretKeyRef:
+                name: mosquitto-credentials
+                key: ZIGBEE2MQTT_PASSWORD
           ZIGBEE2MQTT_CONFIG_SERIAL_BAUDRATE: 115200
           ZIGBEE2MQTT_CONFIG_SERIAL_PORT: &usbdevice /dev/serial/by-id/usb-ITEAD_SONOFF_Zigbee_3.0_USB_Dongle_Plus_V2_20231219170448-if00
         resources:


### PR DESCRIPTION
## Summary

Phase 1 of a **zero-downtime** rollout of authentication on the mosquitto broker. This PR adds password-based auth **without** removing anonymous access, so nothing breaks when ArgoCD syncs. The broker accepts both anonymous and authenticated clients in parallel until every client is migrated.

Broker: `app-template` 1.5.1, listener `1883`, LoadBalancer `192.168.1.222`, PVC `mosquitto-data`. Secrets use **ESO** (`ClusterSecretStore onepassword`, vault `homelab`) — verified `Ready=True` on the live cluster.

---

## ⚠️ PREREQUISITE — create the 1Password item BEFORE merging

Wiring zigbee2mqtt to a Secret that does not yet exist will leave its pod in `CreateContainerConfigError`. **Create the 1Password item first, confirm `mosquitto-credentials` Secret appears in `home-automation`, then merge.**

**1Password item (vault `homelab`):**
- **Item name:** `mqtt-credentials`
- **Fields** (one username + one password per client — pick any strong passwords):

  | field | example value |
  |---|---|
  | `homeassistant_username` | `homeassistant` |
  | `homeassistant_password` | (strong) |
  | `zigbee2mqtt_username` | `zigbee2mqtt` |
  | `zigbee2mqtt_password` | (strong) |
  | `nodered_username` | `nodered` |
  | `nodered_password` | (strong) |
  | `philips_username` | `philips` |
  | `philips_password` | (strong) |

Per-client users (least privilege; trivial extra cost — just extra `mosquitto_passwd` lines).

---

## 1. What is automated in git (this PR)

- **`mosquitto/externalsecret.yaml`** — `ExternalSecret mosquitto-credentials` syncing the 8 fields above from the `mqtt-credentials` 1Password item into Secret `mosquitto-credentials` (namespace `home-automation`). Applied via the mosquitto ArgoCD app's directory source (`exclude: values.yaml`).
- **`mosquitto/values.yaml`**:
  - `mosquitto.conf` gains `password_file /mosquitto/auth/passwd`. **`allow_anonymous true` is kept** (Phase 1).
  - `initContainers.gen-passwd` (image `eclipse-mosquitto:2.0.18`) reads the creds via `envFrom: secretRef: mosquitto-credentials` and runs `mosquitto_passwd -b -c` (then `-b`) to build the **hashed** passwd file into a shared `emptyDir`.
  - new `persistence.auth` emptyDir mounted at `/mosquitto/auth` in the main container (auto-mounted) and in the initContainer (explicit mount).
  - Chosen **approach (a)** (initContainer + shared emptyDir) over storing a pre-hashed file: app-template 1.5.1 supports `initContainers` + `persistence` emptyDir cleanly (verified by local `helm template`), and it keeps only plaintext creds in 1Password (no manual hashing / rehash on rotation).
- **`zigbee2mqtt/values.yaml`** — `ZIGBEE2MQTT_CONFIG_MQTT_USER` / `_PASSWORD` wired from `mosquitto-credentials` via `secretKeyRef` (app-template 2.5.0 supports `env` `valueFrom`; verified by local `helm template`).

Both renders validated locally with `helm template`.

---

## 2. Per-client classification & manual steps

| Client | Where MQTT creds live | This PR | Action |
|---|---|---|---|
| **zigbee2mqtt** | env (`ZIGBEE2MQTT_CONFIG_MQTT_USER/_PASSWORD`) | ✅ wired in git | none — picks up creds on next sync/restart |
| **home-assistant** | PVC `.storage` config entry (MQTT integration, set via UI) | ❌ PVC-only | **manual** (below) |
| **node-red** | PVC `flows_cred.json` (broker config node) | ❌ PVC-only | **manual** (below) |
| **philips-bridge** | script ConfigMap; `paho.mqtt` client has **no** `username_pw_set` | ❌ needs code change | **manual** (below) |

### home-assistant (manual)
Settings → Devices & Services → **MQTT** → Configure (or re-add integration) → set **Username** = `homeassistant_username`, **Password** = `homeassistant_password`. Reload the MQTT integration. Stored in the HA config PVC, not git.

### node-red (manual)
Open node-red UI → double-click the **MQTT broker** config node → **Security** tab → set Username `nodered_username` / Password `nodered_password` → Update → **Deploy**. Stored in `flows_cred.json` on the node-red PVC, not git.

### philips-bridge (manual — code change required)
`philips-bridge/configmap.yaml` `bridge.py` calls `mqtt.connect()` with no auth. Before Phase 2, add credentials, e.g.:
```python
MQTT_USER = os.environ.get("MQTT_USER")
MQTT_PASS = os.environ.get("MQTT_PASS")
if MQTT_USER:
    mqttc.username_pw_set(MQTT_USER, MQTT_PASS)
```
and inject `MQTT_USER`/`MQTT_PASS` into `deployment.yaml` from `mosquitto-credentials` (`PHILIPS_USERNAME`/`PHILIPS_PASSWORD`) via `valueFrom.secretKeyRef`. (Left out of this PR to keep Phase 1 to broker-side + zero-risk changes; can be a follow-up PR.)

---

## 3. Phase 2 (DO NOT do in this PR)

Once **all four** clients are confirmed authenticated, a separate PR flips one line in `mosquitto/values.yaml`:
```diff
-        allow_anonymous true
+        allow_anonymous false
```

**Verification before merging Phase 2:**
- Confirm authenticated clients are connected (broker logs / each client's UI shows connected).
- Confirm an anonymous connect is now rejected, e.g. from a debug pod:
  ```sh
  mosquitto_sub -h mosquitto.home-automation.svc.cluster.local -p 1883 -t test -C 1 -W 5
  # expected: "Connection Refused: not authorised."
  ```
- And that an authenticated connect still works:
  ```sh
  mosquitto_sub -h mosquitto.home-automation.svc.cluster.local -p 1883 \
    -u homeassistant -P <pass> -t test -C 1 -W 5
  ```

## 🚨 Do NOT merge Phase 2 until ALL clients (zigbee2mqtt, home-assistant, node-red, philips-bridge) are verified authenticated — flipping `allow_anonymous false` early will disconnect any client still connecting anonymously and break the house.

🤖 Generated with [Claude Code](https://claude.com/claude-code)