### PR TITLE
fix: gluetun crash + wrong CIDRs after k3s→Talos migration

### DIFF
--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -14,7 +14,7 @@ env:
   QBT_BitTorrent__Session__InterfaceName: wg0
   QBT_Preferences__WebUI__AuthSubnetWhitelistEnabled: true
   # Network ranges allowed to bypass WebUI auth
-  QBT_Preferences__WebUI__AuthSubnetWhitelist: "192.168.1.0/24, 10.42.0.0/16, 10.43.0.0/16"
+  QBT_Preferences__WebUI__AuthSubnetWhitelist: "192.168.1.0/24, 10.244.0.0/16, 10.96.0.0/12"
   QBT_Preferences__WebUI__LocalHostAuth: false
   QBT_BitTorrent__Session__DefaultSavePath: "/data/downloads"
 
@@ -44,7 +44,7 @@ addons:
     gluetun:
       image:
         repository: ghcr.io/qdm12/gluetun
-        tag: v3.39.1
+        tag: v3.41.1
     env:
       - name: VPN_SERVICE_PROVIDER
         value: airvpn
@@ -57,7 +57,7 @@ addons:
       - name: FIREWALL_VPN_INPUT_PORTS
         value: 21188
       - name: FIREWALL_OUTBOUND_SUBNETS
-        value: "10.42.0.0/16,10.43.0.0/16"
+        value: "10.244.0.0/16,10.96.0.0/12"
       - name: DOT
         value: "off"
       - name: SERVER_COUNTRIES


### PR DESCRIPTION
## Summary

- **gluetun crash**: v3.39.1 calls `chown /etc/unbound` at startup even with `DOT=off`, which fails under the `allowPrivilegeEscalation=false` securityContext added in #307. Bumped to v3.41.1 where this is fixed.
- **Wrong CIDRs**: `FIREWALL_OUTBOUND_SUBNETS` and the WebUI auth subnet whitelist both had k3s defaults (`10.42.0.0/16`, `10.43.0.0/16`). On Talos/Cilium the actual ranges are pod `10.244.0.0/16` and service `10.96.0.0/12`.

With the wrong outbound subnets, traffic from qbittorrent to in-cluster services (e.g. Sonarr/Radarr API calls) would be incorrectly routed through the VPN instead of the cluster network, and the WebUI would reject requests from in-cluster clients.

## Test plan

- [ ] ArgoCD syncs and pod comes up 3/3 (gluetun no longer crashes)
- [ ] gluetun logs show \`Public IP address is ... (Netherlands, ...)\` confirming VPN is connected
- [ ] Verify outbound IP from qbittorrent container: \`kubectl exec -n media qbittorrent-0 -c netshoot -- curl -s https://api.ipify.org\` → should return VPN IP (Netherlands)
- [ ] Verify in-cluster traffic works (Sonarr can reach qbittorrent API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)