### PR TITLE
fix: add MKNOD cap — gluetun v3.41.1 requires it on Talos

### DIFF
--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -14,7 +14,7 @@ env:
   QBT_BitTorrent__Session__InterfaceName: wg0
   QBT_Preferences__WebUI__AuthSubnetWhitelistEnabled: true
   # Network ranges allowed to bypass WebUI auth
-  QBT_Preferences__WebUI__AuthSubnetWhitelist: "192.168.1.0/24, 10.42.0.0/16, 10.43.0.0/16"
+  QBT_Preferences__WebUI__AuthSubnetWhitelist: "192.168.1.0/24, 10.244.0.0/16, 10.96.0.0/12"
   QBT_Preferences__WebUI__LocalHostAuth: false
   QBT_BitTorrent__Session__DefaultSavePath: "/data/downloads"
 
@@ -44,7 +44,7 @@ addons:
     gluetun:
       image:
         repository: ghcr.io/qdm12/gluetun
-        tag: v3.39.1
+        tag: v3.41.1
     env:
       - name: VPN_SERVICE_PROVIDER
         value: airvpn
@@ -57,7 +57,7 @@ addons:
       - name: FIREWALL_VPN_INPUT_PORTS
         value: 21188
       - name: FIREWALL_OUTBOUND_SUBNETS
-        value: "10.42.0.0/16,10.43.0.0/16"
+        value: "10.244.0.0/16,10.96.0.0/12"
       - name: DOT
         value: "off"
       - name: SERVER_COUNTRIES

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -89,18 +89,19 @@ addons:
       - name: HEALTH_SUCCESS_WAIT_DURATION
         value: "1200s"
     securityContext:
-      # NET_ADMIN is required for gluetun to create/configure the wg0 WireGuard
-      # interface and manage routing/firewall rules inside the pod netns.
-      # privileged + SYS_MODULE removed: WireGuard is compiled into the Talos
-      # kernel (verified: /sys/module/wireguard present, absent from
-      # /proc/modules => built-in), so gluetun uses the kernelspace
-      # implementation and needs only NET_ADMIN — no module loading, no
-      # /dev/net/tun device, no privileged mode. SYS_MODULE would allow loading
-      # arbitrary host kernel modules (full host compromise).
+      # NET_ADMIN: required for wg0 interface + iptables rules.
+      # MKNOD: gluetun v3.40+ unconditionally creates /dev/net/tun at startup
+      # before selecting the WireGuard implementation — Talos nodes don't have
+      # the TUN device node, so gluetun must mknod it. The node has no
+      # /dev/net/tun to mount as hostPath. Once created, gluetun detects
+      # /sys/module/wireguard and uses the kernelspace implementation (TUN
+      # node exists but carries no traffic). SYS_MODULE and privileged are
+      # intentionally absent.
       allowPrivilegeEscalation: false
       capabilities:
         add:
           - NET_ADMIN
+          - MKNOD
         drop:
           - ALL
 


### PR DESCRIPTION
Follow-up to #309 — fixing the second crash discovered during verification.

## Problem

After bumping to gluetun v3.41.1, the container crashes at startup with:
```
ERROR creating tun device: creating TUN device file node: operation not permitted
```

gluetun v3.40+ unconditionally calls \`mknod /dev/net/tun\` before selecting the WireGuard implementation. With \`drop: ALL\` (from #307), \`CAP_MKNOD\` is gone. Talos nodes have no \`/dev/net/tun\` to mount as a hostPath (confirmed: \`ls /dev/net/tun\` fails even from a privileged Cilium pod).

## Fix

Add \`MKNOD\` to the capability list. Once gluetun creates the device node, it detects \`/sys/module/wireguard\` and uses the kernelspace implementation — the TUN node exists in the container but carries no traffic.

Security posture vs old config: still no \`privileged\`, no \`SYS_MODULE\`, no \`NET_RAW\` — just \`NET_ADMIN + MKNOD\` instead of full privilege.

## Test plan

- [ ] Pod comes up 3/3
- [ ] gluetun logs show \`Using available kernelspace implementation\` + \`Public IP address is ... (Netherlands)\`
- [ ] \`kubectl exec -n media qbittorrent-0 -c netshoot -- curl -s https://api.ipify.org\` returns VPN IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)