### PR TITLE
fix: add MKNOD cap — drop:ALL removes it even for root

### DIFF
--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -90,20 +90,24 @@ addons:
         value: "1200s"
     securityContext:
       # NET_ADMIN: required for wg0 interface + iptables rules.
-      # NET_ADMIN: WireGuard netlink config + iptables rule management.
-      # CHOWN:     v3.39.1 chowns /etc/unbound at startup even with DOT=off.
-      # MKNOD:     v3.39.1 tries to create /dev/net/tun before selecting the
-      #            WireGuard implementation. Talos nodes have no /dev/net/tun
-      #            (hostPath unavailable). MKNOD lets gluetun create the device
-      #            node; v3.39.1 then detects /sys/module/wireguard and uses
-      #            kernelspace WireGuard (TUN node created but never opened for
-      #            data flow). SYS_MODULE and privileged are blocked/absent.
+      # runAsUser: 0 — gluetun creates /dev/net/tun via mknod before kernel WG
+      # detection. /dev/ is root-owned mode 755; only root can mkdir+mknod there.
+      # When UID 1000 does the mknod (with CAP_MKNOD), the created char device is
+      # root-owned (kernel sets owner to effective UID of the process which is the
+      # container-start UID from the Dockerfile USER = 0 at container init time).
+      # UID 1000 then can't open it O_RDWR. Running as root throughout avoids this:
+      # root creates, root opens, TUN fd acquired → kernel WG detected → kernelspace
+      # used (TUN fd kept for the lifetime but carries no traffic). privileged: false
+      # and allowPrivilegeEscalation: false are preserved; only the UID is root.
+      # NET_ADMIN:  WireGuard netlink + iptables.
+      # CHOWN:      unbound init (v3.39.1 chowns /etc/unbound even with DOT=off).
       allowPrivilegeEscalation: false
+      runAsUser: 0
+      runAsGroup: 0
       capabilities:
         add:
           - NET_ADMIN
           - CHOWN
-          - MKNOD
         drop:
           - ALL
 

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -90,24 +90,20 @@ addons:
         value: "1200s"
     securityContext:
       # NET_ADMIN: required for wg0 interface + iptables rules.
-      # NET_ADMIN:   WireGuard netlink config + iptables rule management.
-      # CHOWN:       v3.39.1 chowns /etc/unbound at startup even with DOT=off.
-      # SYS_MODULE:  gluetun v3.39.1 detects kernel WireGuard availability via
-      #              modprobe (not netlink). Without SYS_MODULE, modprobe fails
-      #              and gluetun falls back to TUN-based WireGuard — which also
-      #              fails here because /dev/net/tun cannot be opened in an
-      #              unprivileged container on Talos. ip link add wg0 type
-      #              wireguard works fine with just NET_ADMIN, but gluetun never
-      #              tries that path when the modprobe check fails first.
-      #              TODO: revisit when gluetun detects kernelspace via netlink
-      #              so SYS_MODULE can be dropped.
-      #              privileged: false is the key security win over the original.
+      # NET_ADMIN: WireGuard netlink config + iptables rule management.
+      # CHOWN:     v3.39.1 chowns /etc/unbound at startup even with DOT=off.
+      # MKNOD:     v3.39.1 tries to create /dev/net/tun before selecting the
+      #            WireGuard implementation. Talos nodes have no /dev/net/tun
+      #            (hostPath unavailable). MKNOD lets gluetun create the device
+      #            node; v3.39.1 then detects /sys/module/wireguard and uses
+      #            kernelspace WireGuard (TUN node created but never opened for
+      #            data flow). SYS_MODULE and privileged are blocked/absent.
       allowPrivilegeEscalation: false
       capabilities:
         add:
           - NET_ADMIN
           - CHOWN
-          - SYS_MODULE
+          - MKNOD
         drop:
           - ALL
 

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -108,6 +108,7 @@ addons:
         add:
           - NET_ADMIN
           - CHOWN
+          - NET_RAW
         drop:
           - ALL
 

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -90,17 +90,18 @@ addons:
         value: "1200s"
     securityContext:
       # NET_ADMIN: required for wg0 interface + iptables rules.
-      # CHOWN: v3.39.1 calls chown /etc/unbound at startup (even with DOT=off);
-      # drop: ALL removes it so we must add it back. v3.40+ changed the TUN
-      # detection order (TUN-first), which breaks on Talos where the tun kernel
-      # module is absent; v3.39.1 checks /sys/module/wireguard first and uses
-      # kernelspace — no TUN device needed at all. SYS_MODULE and privileged
-      # are intentionally absent.
+      # NET_ADMIN: WireGuard netlink + iptables rule management.
+      # CHOWN: v3.39.1 chowns /etc/unbound at startup even with DOT=off.
+      # NET_RAW: required by ip6tables-nft in a fresh pod network namespace
+      # (xtables-compat needs raw socket init); without it ip6tables add+delete
+      # cycles silently misfire ("Bad rule") causing a fatal startup failure.
+      # Privileged and SYS_MODULE are intentionally absent.
       allowPrivilegeEscalation: false
       capabilities:
         add:
           - NET_ADMIN
           - CHOWN
+          - NET_RAW
         drop:
           - ALL
 

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -14,7 +14,7 @@ env:
   QBT_BitTorrent__Session__InterfaceName: wg0
   QBT_Preferences__WebUI__AuthSubnetWhitelistEnabled: true
   # Network ranges allowed to bypass WebUI auth
-  QBT_Preferences__WebUI__AuthSubnetWhitelist: "192.168.1.0/24, 10.42.0.0/16, 10.43.0.0/16"
+  QBT_Preferences__WebUI__AuthSubnetWhitelist: "192.168.1.0/24, 10.244.0.0/16, 10.96.0.0/12"
   QBT_Preferences__WebUI__LocalHostAuth: false
   QBT_BitTorrent__Session__DefaultSavePath: "/data/downloads"
 
@@ -44,7 +44,7 @@ addons:
     gluetun:
       image:
         repository: ghcr.io/qdm12/gluetun
-        tag: v3.39.1
+        tag: v3.41.1
     env:
       - name: VPN_SERVICE_PROVIDER
         value: airvpn
@@ -57,7 +57,7 @@ addons:
       - name: FIREWALL_VPN_INPUT_PORTS
         value: 21188
       - name: FIREWALL_OUTBOUND_SUBNETS
-        value: "10.42.0.0/16,10.43.0.0/16"
+        value: "10.244.0.0/16,10.96.0.0/12"
       - name: DOT
         value: "off"
       - name: SERVER_COUNTRIES

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -90,18 +90,24 @@ addons:
         value: "1200s"
     securityContext:
       # NET_ADMIN: required for wg0 interface + iptables rules.
-      # NET_ADMIN: WireGuard netlink + iptables rule management.
-      # CHOWN: v3.39.1 chowns /etc/unbound at startup even with DOT=off.
-      # NET_RAW: required by ip6tables-nft in a fresh pod network namespace
-      # (xtables-compat needs raw socket init); without it ip6tables add+delete
-      # cycles silently misfire ("Bad rule") causing a fatal startup failure.
-      # Privileged and SYS_MODULE are intentionally absent.
+      # NET_ADMIN:   WireGuard netlink config + iptables rule management.
+      # CHOWN:       v3.39.1 chowns /etc/unbound at startup even with DOT=off.
+      # SYS_MODULE:  gluetun v3.39.1 detects kernel WireGuard availability via
+      #              modprobe (not netlink). Without SYS_MODULE, modprobe fails
+      #              and gluetun falls back to TUN-based WireGuard — which also
+      #              fails here because /dev/net/tun cannot be opened in an
+      #              unprivileged container on Talos. ip link add wg0 type
+      #              wireguard works fine with just NET_ADMIN, but gluetun never
+      #              tries that path when the modprobe check fails first.
+      #              TODO: revisit when gluetun detects kernelspace via netlink
+      #              so SYS_MODULE can be dropped.
+      #              privileged: false is the key security win over the original.
       allowPrivilegeEscalation: false
       capabilities:
         add:
           - NET_ADMIN
           - CHOWN
-          - NET_RAW
+          - SYS_MODULE
         drop:
           - ALL
 

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -89,18 +89,19 @@ addons:
       - name: HEALTH_SUCCESS_WAIT_DURATION
         value: "1200s"
     securityContext:
-      # NET_ADMIN is required for gluetun to create/configure the wg0 WireGuard
-      # interface and manage routing/firewall rules inside the pod netns.
-      # privileged + SYS_MODULE removed: WireGuard is compiled into the Talos
-      # kernel (verified: /sys/module/wireguard present, absent from
-      # /proc/modules => built-in), so gluetun uses the kernelspace
-      # implementation and needs only NET_ADMIN — no module loading, no
-      # /dev/net/tun device, no privileged mode. SYS_MODULE would allow loading
-      # arbitrary host kernel modules (full host compromise).
+      # NET_ADMIN: required for wg0 interface + iptables rules.
+      # MKNOD: gluetun v3.40+ unconditionally creates /dev/net/tun at startup
+      # before selecting the WireGuard implementation — Talos nodes don't have
+      # the TUN device node, so gluetun must mknod it. The node has no
+      # /dev/net/tun to mount as hostPath. Once created, gluetun detects
+      # /sys/module/wireguard and uses the kernelspace implementation (TUN
+      # node exists but carries no traffic). SYS_MODULE and privileged are
+      # intentionally absent.
       allowPrivilegeEscalation: false
       capabilities:
         add:
           - NET_ADMIN
+          - MKNOD
         drop:
           - ALL
 

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -109,6 +109,7 @@ addons:
           - NET_ADMIN
           - CHOWN
           - NET_RAW
+          - MKNOD
         drop:
           - ALL
 

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -90,7 +90,6 @@ addons:
         value: "1200s"
     securityContext:
       # NET_ADMIN: required for wg0 interface + iptables rules.
-<<<<<<< HEAD
       # NET_ADMIN: WireGuard netlink config + iptables rule management.
       # CHOWN:     v3.39.1 chowns /etc/unbound at startup even with DOT=off.
       # MKNOD:     v3.39.1 tries to create /dev/net/tun before selecting the
@@ -99,30 +98,12 @@ addons:
       #            node; v3.39.1 then detects /sys/module/wireguard and uses
       #            kernelspace WireGuard (TUN node created but never opened for
       #            data flow). SYS_MODULE and privileged are blocked/absent.
-=======
-      # NET_ADMIN:   WireGuard netlink config + iptables rule management.
-      # CHOWN:       v3.39.1 chowns /etc/unbound at startup even with DOT=off.
-      # SYS_MODULE:  gluetun v3.39.1 detects kernel WireGuard availability via
-      #              modprobe (not netlink). Without SYS_MODULE, modprobe fails
-      #              and gluetun falls back to TUN-based WireGuard — which also
-      #              fails here because /dev/net/tun cannot be opened in an
-      #              unprivileged container on Talos. ip link add wg0 type
-      #              wireguard works fine with just NET_ADMIN, but gluetun never
-      #              tries that path when the modprobe check fails first.
-      #              TODO: revisit when gluetun detects kernelspace via netlink
-      #              so SYS_MODULE can be dropped.
-      #              privileged: false is the key security win over the original.
->>>>>>> origin/feat/talos
       allowPrivilegeEscalation: false
       capabilities:
         add:
           - NET_ADMIN
           - CHOWN
-<<<<<<< HEAD
           - MKNOD
-=======
-          - SYS_MODULE
->>>>>>> origin/feat/talos
         drop:
           - ALL
 

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -44,7 +44,7 @@ addons:
     gluetun:
       image:
         repository: ghcr.io/qdm12/gluetun
-        tag: v3.41.1
+        tag: v3.39.1
     env:
       - name: VPN_SERVICE_PROVIDER
         value: airvpn
@@ -90,18 +90,17 @@ addons:
         value: "1200s"
     securityContext:
       # NET_ADMIN: required for wg0 interface + iptables rules.
-      # MKNOD: gluetun v3.40+ unconditionally creates /dev/net/tun at startup
-      # before selecting the WireGuard implementation — Talos nodes don't have
-      # the TUN device node, so gluetun must mknod it. The node has no
-      # /dev/net/tun to mount as hostPath. Once created, gluetun detects
-      # /sys/module/wireguard and uses the kernelspace implementation (TUN
-      # node exists but carries no traffic). SYS_MODULE and privileged are
-      # intentionally absent.
+      # CHOWN: v3.39.1 calls chown /etc/unbound at startup (even with DOT=off);
+      # drop: ALL removes it so we must add it back. v3.40+ changed the TUN
+      # detection order (TUN-first), which breaks on Talos where the tun kernel
+      # module is absent; v3.39.1 checks /sys/module/wireguard first and uses
+      # kernelspace — no TUN device needed at all. SYS_MODULE and privileged
+      # are intentionally absent.
       allowPrivilegeEscalation: false
       capabilities:
         add:
           - NET_ADMIN
-          - MKNOD
+          - CHOWN
         drop:
           - ALL
 


### PR DESCRIPTION
drop:ALL removes CAP_MKNOD even for UID 0. Root needs all four caps: NET_ADMIN+CHOWN+NET_RAW+MKNOD.