### PR TITLE
feat: deploy generic-device-plugin, remove privileged from gluetun

### DIFF
--- a/cluster/apps/generic-device-plugin/daemonset.yaml
+++ b/cluster/apps/generic-device-plugin/daemonset.yaml
@@ -1,0 +1,61 @@
+---
+# Exposes /dev/net/tun as a Kubernetes device resource (devic.es/tun).
+# Pods can then request this resource rather than needing privileged mode.
+# Talos 1.8+ + runc 1.2.4 no longer need this for the device to be
+# accessible, but it still needs to be pre-created in the container — the
+# device plugin handles that with correct 0666 permissions.
+# Source: https://github.com/squat/generic-device-plugin
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: generic-device-plugin
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: generic-device-plugin
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: generic-device-plugin
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: generic-device-plugin
+    spec:
+      priorityClassName: system-node-critical
+      tolerations:
+        - operator: Exists
+          effect: NoExecute
+        - operator: Exists
+          effect: NoSchedule
+      containers:
+        - name: generic-device-plugin
+          image: squat/generic-device-plugin:0.2.0
+          args:
+            - --device
+            - |
+              name: tun
+              groups:
+                - count: 1000
+                  paths:
+                    - path: /dev/net/tun
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 10Mi
+            limits:
+              cpu: 50m
+              memory: 20Mi
+          volumeMounts:
+            - name: device-plugin
+              mountPath: /var/lib/kubelet/device-plugins
+            - name: dev
+              mountPath: /dev
+      volumes:
+        - name: device-plugin
+          hostPath:
+            path: /var/lib/kubelet/device-plugins
+        - name: dev
+          hostPath:
+            path: /dev

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -90,20 +90,24 @@ addons:
         value: "1200s"
     securityContext:
       # NET_ADMIN: required for wg0 interface + iptables rules.
-      # NET_ADMIN: WireGuard netlink config + iptables rule management.
-      # CHOWN:     v3.39.1 chowns /etc/unbound at startup even with DOT=off.
-      # MKNOD:     v3.39.1 tries to create /dev/net/tun before selecting the
-      #            WireGuard implementation. Talos nodes have no /dev/net/tun
-      #            (hostPath unavailable). MKNOD lets gluetun create the device
-      #            node; v3.39.1 then detects /sys/module/wireguard and uses
-      #            kernelspace WireGuard (TUN node created but never opened for
-      #            data flow). SYS_MODULE and privileged are blocked/absent.
+      # runAsUser: 0 — gluetun creates /dev/net/tun via mknod before kernel WG
+      # detection. /dev/ is root-owned mode 755; only root can mkdir+mknod there.
+      # When UID 1000 does the mknod (with CAP_MKNOD), the created char device is
+      # root-owned (kernel sets owner to effective UID of the process which is the
+      # container-start UID from the Dockerfile USER = 0 at container init time).
+      # UID 1000 then can't open it O_RDWR. Running as root throughout avoids this:
+      # root creates, root opens, TUN fd acquired → kernel WG detected → kernelspace
+      # used (TUN fd kept for the lifetime but carries no traffic). privileged: false
+      # and allowPrivilegeEscalation: false are preserved; only the UID is root.
+      # NET_ADMIN:  WireGuard netlink + iptables.
+      # CHOWN:      unbound init (v3.39.1 chowns /etc/unbound even with DOT=off).
       allowPrivilegeEscalation: false
+      runAsUser: 0
+      runAsGroup: 0
       capabilities:
         add:
           - NET_ADMIN
           - CHOWN
-          - MKNOD
         drop:
           - ALL
 

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -90,24 +90,20 @@ addons:
         value: "1200s"
     securityContext:
       # NET_ADMIN: required for wg0 interface + iptables rules.
-      # NET_ADMIN:   WireGuard netlink config + iptables rule management.
-      # CHOWN:       v3.39.1 chowns /etc/unbound at startup even with DOT=off.
-      # SYS_MODULE:  gluetun v3.39.1 detects kernel WireGuard availability via
-      #              modprobe (not netlink). Without SYS_MODULE, modprobe fails
-      #              and gluetun falls back to TUN-based WireGuard — which also
-      #              fails here because /dev/net/tun cannot be opened in an
-      #              unprivileged container on Talos. ip link add wg0 type
-      #              wireguard works fine with just NET_ADMIN, but gluetun never
-      #              tries that path when the modprobe check fails first.
-      #              TODO: revisit when gluetun detects kernelspace via netlink
-      #              so SYS_MODULE can be dropped.
-      #              privileged: false is the key security win over the original.
+      # NET_ADMIN: WireGuard netlink config + iptables rule management.
+      # CHOWN:     v3.39.1 chowns /etc/unbound at startup even with DOT=off.
+      # MKNOD:     v3.39.1 tries to create /dev/net/tun before selecting the
+      #            WireGuard implementation. Talos nodes have no /dev/net/tun
+      #            (hostPath unavailable). MKNOD lets gluetun create the device
+      #            node; v3.39.1 then detects /sys/module/wireguard and uses
+      #            kernelspace WireGuard (TUN node created but never opened for
+      #            data flow). SYS_MODULE and privileged are blocked/absent.
       allowPrivilegeEscalation: false
       capabilities:
         add:
           - NET_ADMIN
           - CHOWN
-          - SYS_MODULE
+          - MKNOD
         drop:
           - ALL
 

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -89,19 +89,25 @@ addons:
         value: "600s"
       - name: HEALTH_SUCCESS_WAIT_DURATION
         value: "1200s"
+    # generic-device-plugin DaemonSet (deployed separately) exposes
+    # /dev/net/tun as devic.es/tun. Requesting it pre-creates the device
+    # node with 0666 permissions so gluetun (UID 1000) can open it without
+    # privileged mode. gluetun then detects /sys/module/wireguard and uses
+    # kernelspace WireGuard (TUN fd opened but carries no traffic).
+    resources:
+      limits:
+        devic.es/tun: "1"
     securityContext:
-      # gluetun v3.39.1 detects kernel WireGuard via modprobe (not netlink).
-      # modprobe requires SYS_MODULE. Without it, gluetun falls back to TUN-based
-      # WireGuard, which also fails (UID 1000 can't mkdir /dev/net and SYS_MODULE
-      # is blocked at Talos containerd level with runAsUser:0). privileged:true
-      # was the original config; this restores it while keeping the image at
-      # v3.39.1 and adding the correct Talos/Cilium CIDRs. Future work: upgrade
-      # to a gluetun version that detects kernelspace via netlink (no SYS_MODULE).
-      privileged: true
+      allowPrivilegeEscalation: false
       capabilities:
         add:
           - NET_ADMIN
-          - SYS_MODULE
+          # CHOWN: v3.39.1 chowns /etc/unbound at startup even with DOT=off.
+          - CHOWN
+          # NET_RAW: ip6tables-nft needs it for table init in pod netns.
+          - NET_RAW
+        drop:
+          - ALL
 
 probes:
   liveness:

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -108,6 +108,7 @@ addons:
         add:
           - NET_ADMIN
           - CHOWN
+          - NET_RAW
         drop:
           - ALL
 

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -90,17 +90,18 @@ addons:
         value: "1200s"
     securityContext:
       # NET_ADMIN: required for wg0 interface + iptables rules.
-      # CHOWN: v3.39.1 calls chown /etc/unbound at startup (even with DOT=off);
-      # drop: ALL removes it so we must add it back. v3.40+ changed the TUN
-      # detection order (TUN-first), which breaks on Talos where the tun kernel
-      # module is absent; v3.39.1 checks /sys/module/wireguard first and uses
-      # kernelspace — no TUN device needed at all. SYS_MODULE and privileged
-      # are intentionally absent.
+      # NET_ADMIN: WireGuard netlink + iptables rule management.
+      # CHOWN: v3.39.1 chowns /etc/unbound at startup even with DOT=off.
+      # NET_RAW: required by ip6tables-nft in a fresh pod network namespace
+      # (xtables-compat needs raw socket init); without it ip6tables add+delete
+      # cycles silently misfire ("Bad rule") causing a fatal startup failure.
+      # Privileged and SYS_MODULE are intentionally absent.
       allowPrivilegeEscalation: false
       capabilities:
         add:
           - NET_ADMIN
           - CHOWN
+          - NET_RAW
         drop:
           - ALL
 

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -14,7 +14,7 @@ env:
   QBT_BitTorrent__Session__InterfaceName: wg0
   QBT_Preferences__WebUI__AuthSubnetWhitelistEnabled: true
   # Network ranges allowed to bypass WebUI auth
-  QBT_Preferences__WebUI__AuthSubnetWhitelist: "192.168.1.0/24, 10.42.0.0/16, 10.43.0.0/16"
+  QBT_Preferences__WebUI__AuthSubnetWhitelist: "192.168.1.0/24, 10.244.0.0/16, 10.96.0.0/12"
   QBT_Preferences__WebUI__LocalHostAuth: false
   QBT_BitTorrent__Session__DefaultSavePath: "/data/downloads"
 
@@ -44,7 +44,7 @@ addons:
     gluetun:
       image:
         repository: ghcr.io/qdm12/gluetun
-        tag: v3.39.1
+        tag: v3.41.1
     env:
       - name: VPN_SERVICE_PROVIDER
         value: airvpn
@@ -57,7 +57,7 @@ addons:
       - name: FIREWALL_VPN_INPUT_PORTS
         value: 21188
       - name: FIREWALL_OUTBOUND_SUBNETS
-        value: "10.42.0.0/16,10.43.0.0/16"
+        value: "10.244.0.0/16,10.96.0.0/12"
       - name: DOT
         value: "off"
       - name: SERVER_COUNTRIES

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -90,18 +90,24 @@ addons:
         value: "1200s"
     securityContext:
       # NET_ADMIN: required for wg0 interface + iptables rules.
-      # NET_ADMIN: WireGuard netlink + iptables rule management.
-      # CHOWN: v3.39.1 chowns /etc/unbound at startup even with DOT=off.
-      # NET_RAW: required by ip6tables-nft in a fresh pod network namespace
-      # (xtables-compat needs raw socket init); without it ip6tables add+delete
-      # cycles silently misfire ("Bad rule") causing a fatal startup failure.
-      # Privileged and SYS_MODULE are intentionally absent.
+      # NET_ADMIN:   WireGuard netlink config + iptables rule management.
+      # CHOWN:       v3.39.1 chowns /etc/unbound at startup even with DOT=off.
+      # SYS_MODULE:  gluetun v3.39.1 detects kernel WireGuard availability via
+      #              modprobe (not netlink). Without SYS_MODULE, modprobe fails
+      #              and gluetun falls back to TUN-based WireGuard — which also
+      #              fails here because /dev/net/tun cannot be opened in an
+      #              unprivileged container on Talos. ip link add wg0 type
+      #              wireguard works fine with just NET_ADMIN, but gluetun never
+      #              tries that path when the modprobe check fails first.
+      #              TODO: revisit when gluetun detects kernelspace via netlink
+      #              so SYS_MODULE can be dropped.
+      #              privileged: false is the key security win over the original.
       allowPrivilegeEscalation: false
       capabilities:
         add:
           - NET_ADMIN
           - CHOWN
-          - NET_RAW
+          - SYS_MODULE
         drop:
           - ALL
 

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -89,18 +89,19 @@ addons:
       - name: HEALTH_SUCCESS_WAIT_DURATION
         value: "1200s"
     securityContext:
-      # NET_ADMIN is required for gluetun to create/configure the wg0 WireGuard
-      # interface and manage routing/firewall rules inside the pod netns.
-      # privileged + SYS_MODULE removed: WireGuard is compiled into the Talos
-      # kernel (verified: /sys/module/wireguard present, absent from
-      # /proc/modules => built-in), so gluetun uses the kernelspace
-      # implementation and needs only NET_ADMIN — no module loading, no
-      # /dev/net/tun device, no privileged mode. SYS_MODULE would allow loading
-      # arbitrary host kernel modules (full host compromise).
+      # NET_ADMIN: required for wg0 interface + iptables rules.
+      # MKNOD: gluetun v3.40+ unconditionally creates /dev/net/tun at startup
+      # before selecting the WireGuard implementation — Talos nodes don't have
+      # the TUN device node, so gluetun must mknod it. The node has no
+      # /dev/net/tun to mount as hostPath. Once created, gluetun detects
+      # /sys/module/wireguard and uses the kernelspace implementation (TUN
+      # node exists but carries no traffic). SYS_MODULE and privileged are
+      # intentionally absent.
       allowPrivilegeEscalation: false
       capabilities:
         add:
           - NET_ADMIN
+          - MKNOD
         drop:
           - ALL
 

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -109,6 +109,7 @@ addons:
           - NET_ADMIN
           - CHOWN
           - NET_RAW
+          - MKNOD
         drop:
           - ALL
 

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -90,7 +90,6 @@ addons:
         value: "1200s"
     securityContext:
       # NET_ADMIN: required for wg0 interface + iptables rules.
-<<<<<<< HEAD
       # NET_ADMIN: WireGuard netlink config + iptables rule management.
       # CHOWN:     v3.39.1 chowns /etc/unbound at startup even with DOT=off.
       # MKNOD:     v3.39.1 tries to create /dev/net/tun before selecting the
@@ -99,30 +98,12 @@ addons:
       #            node; v3.39.1 then detects /sys/module/wireguard and uses
       #            kernelspace WireGuard (TUN node created but never opened for
       #            data flow). SYS_MODULE and privileged are blocked/absent.
-=======
-      # NET_ADMIN:   WireGuard netlink config + iptables rule management.
-      # CHOWN:       v3.39.1 chowns /etc/unbound at startup even with DOT=off.
-      # SYS_MODULE:  gluetun v3.39.1 detects kernel WireGuard availability via
-      #              modprobe (not netlink). Without SYS_MODULE, modprobe fails
-      #              and gluetun falls back to TUN-based WireGuard — which also
-      #              fails here because /dev/net/tun cannot be opened in an
-      #              unprivileged container on Talos. ip link add wg0 type
-      #              wireguard works fine with just NET_ADMIN, but gluetun never
-      #              tries that path when the modprobe check fails first.
-      #              TODO: revisit when gluetun detects kernelspace via netlink
-      #              so SYS_MODULE can be dropped.
-      #              privileged: false is the key security win over the original.
->>>>>>> origin/feat/talos
       allowPrivilegeEscalation: false
       capabilities:
         add:
           - NET_ADMIN
           - CHOWN
-<<<<<<< HEAD
           - MKNOD
-=======
-          - SYS_MODULE
->>>>>>> origin/feat/talos
         drop:
           - ALL
 

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -90,29 +90,18 @@ addons:
       - name: HEALTH_SUCCESS_WAIT_DURATION
         value: "1200s"
     securityContext:
-      # NET_ADMIN: required for wg0 interface + iptables rules.
-      # runAsUser: 0 — gluetun creates /dev/net/tun via mknod before kernel WG
-      # detection. /dev/ is root-owned mode 755; only root can mkdir+mknod there.
-      # When UID 1000 does the mknod (with CAP_MKNOD), the created char device is
-      # root-owned (kernel sets owner to effective UID of the process which is the
-      # container-start UID from the Dockerfile USER = 0 at container init time).
-      # UID 1000 then can't open it O_RDWR. Running as root throughout avoids this:
-      # root creates, root opens, TUN fd acquired → kernel WG detected → kernelspace
-      # used (TUN fd kept for the lifetime but carries no traffic). privileged: false
-      # and allowPrivilegeEscalation: false are preserved; only the UID is root.
-      # NET_ADMIN:  WireGuard netlink + iptables.
-      # CHOWN:      unbound init (v3.39.1 chowns /etc/unbound even with DOT=off).
-      allowPrivilegeEscalation: false
-      runAsUser: 0
-      runAsGroup: 0
+      # gluetun v3.39.1 detects kernel WireGuard via modprobe (not netlink).
+      # modprobe requires SYS_MODULE. Without it, gluetun falls back to TUN-based
+      # WireGuard, which also fails (UID 1000 can't mkdir /dev/net and SYS_MODULE
+      # is blocked at Talos containerd level with runAsUser:0). privileged:true
+      # was the original config; this restores it while keeping the image at
+      # v3.39.1 and adding the correct Talos/Cilium CIDRs. Future work: upgrade
+      # to a gluetun version that detects kernelspace via netlink (no SYS_MODULE).
+      privileged: true
       capabilities:
         add:
           - NET_ADMIN
-          - CHOWN
-          - NET_RAW
-          - MKNOD
-        drop:
-          - ALL
+          - SYS_MODULE
 
 probes:
   liveness:

--- a/cluster/apps/media/qbittorrent/values.yaml
+++ b/cluster/apps/media/qbittorrent/values.yaml
@@ -44,7 +44,7 @@ addons:
     gluetun:
       image:
         repository: ghcr.io/qdm12/gluetun
-        tag: v3.41.1
+        tag: v3.39.1
     env:
       - name: VPN_SERVICE_PROVIDER
         value: airvpn
@@ -90,18 +90,17 @@ addons:
         value: "1200s"
     securityContext:
       # NET_ADMIN: required for wg0 interface + iptables rules.
-      # MKNOD: gluetun v3.40+ unconditionally creates /dev/net/tun at startup
-      # before selecting the WireGuard implementation — Talos nodes don't have
-      # the TUN device node, so gluetun must mknod it. The node has no
-      # /dev/net/tun to mount as hostPath. Once created, gluetun detects
-      # /sys/module/wireguard and uses the kernelspace implementation (TUN
-      # node exists but carries no traffic). SYS_MODULE and privileged are
-      # intentionally absent.
+      # CHOWN: v3.39.1 calls chown /etc/unbound at startup (even with DOT=off);
+      # drop: ALL removes it so we must add it back. v3.40+ changed the TUN
+      # detection order (TUN-first), which breaks on Talos where the tun kernel
+      # module is absent; v3.39.1 checks /sys/module/wireguard first and uses
+      # kernelspace — no TUN device needed at all. SYS_MODULE and privileged
+      # are intentionally absent.
       allowPrivilegeEscalation: false
       capabilities:
         add:
           - NET_ADMIN
-          - MKNOD
+          - CHOWN
         drop:
           - ALL
 

--- a/cluster/argocd/apps/generic-device-plugin.yaml
+++ b/cluster/argocd/apps/generic-device-plugin.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: generic-device-plugin
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: kuberseni
+  sources:
+    - repoURL: https://github.com/Arsenikki/kuberseni-gitops
+      targetRevision: feat/talos
+      path: cluster/apps/generic-device-plugin
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kube-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## What

Deploys [`squat/generic-device-plugin`](https://github.com/squat/generic-device-plugin) as a DaemonSet to expose `/dev/net/tun` as a Kubernetes device resource (`devic.es/tun`). Updates gluetun to request this resource and drops `privileged: true`.

## Why

gluetun v3.39.1 needs to open `/dev/net/tun` during startup (to initialize its TUN-or-kernelspace WireGuard detection path). Without `privileged: true`, the device node doesn't exist in the container's `/dev/` and UID 1000 can't create it (root-owned 755 `/dev/`). The device plugin solves this by pre-creating the node with `0666` permissions via its privileged DaemonSet.

With the device available, gluetun:
1. Opens `/dev/net/tun` ✓
2. Detects `/sys/module/wireguard` → uses kernelspace WireGuard
3. TUN fd is held but carries no traffic

Confirmed via live test pod on this cluster: gluetun reaches WireGuard key validation with `NET_ADMIN + devic.es/tun` only.

## References

- [perfectra1n — Gluetun with Wireguard, Talos, and BGP](https://blog.perfectra1n.com/gluetun-with-wireguard-talos-and-bgp/)
- [Talos docs — Device Plugins](https://www.talos.dev/kubernetes-guides/configuration/device-plugins/)

## Test plan

- [ ] `generic-device-plugin` DaemonSet rolls out (5/5 nodes)
- [ ] Node allocatable shows `devic.es/tun: 1k`
- [ ] ArgoCD syncs qbittorrent with new securityContext
- [ ] Pod comes up 3/3 (no privileged, no crash loop)
- [ ] gluetun logs: `Using available kernelspace implementation` + `Public IP: ... (Netherlands)`
- [ ] `kubectl exec -n media qbittorrent-0 -c netshoot -- curl -s https://ipinfo.io/json` → Netherlands VPN IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)