### PR TITLE
chore: retarget all ArgoCD apps to main branch

### DIFF
--- a/cluster/argocd/apps/authentik-resources.yaml
+++ b/cluster/argocd/apps/authentik-resources.yaml
@@ -12,7 +12,7 @@ spec:
   project: kuberseni
   source:
     repoURL: https://github.com/Arsenikki/kuberseni-gitops
-    targetRevision: feat/talos
+    targetRevision: main
     path: cluster/apps/authentik/resources
     directory:
       exclude: "values.yaml"

--- a/cluster/argocd/apps/authentik.yaml
+++ b/cluster/argocd/apps/authentik.yaml
@@ -18,7 +18,7 @@ spec:
         valueFiles:
           - $values/cluster/apps/authentik/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/cluster/argocd/apps/captain-core.yaml
+++ b/cluster/argocd/apps/captain-core.yaml
@@ -12,7 +12,7 @@ spec:
   project: kuberseni
   source:
     repoURL: https://github.com/Arsenikki/kuberseni-gitops
-    targetRevision: feat/talos
+    targetRevision: main
     path: cluster/apps/captain-core
   destination:
     server: https://kubernetes.default.svc

--- a/cluster/argocd/apps/cert-manager-resources.yaml
+++ b/cluster/argocd/apps/cert-manager-resources.yaml
@@ -12,7 +12,7 @@ spec:
   project: kuberseni
   source:
     repoURL: https://github.com/Arsenikki/kuberseni-gitops
-    targetRevision: feat/talos
+    targetRevision: main
     path: cluster/apps/cert-manager/resources
     directory:
       exclude: "values.yaml"

--- a/cluster/argocd/apps/cert-manager.yaml
+++ b/cluster/argocd/apps/cert-manager.yaml
@@ -18,7 +18,7 @@ spec:
         valueFiles:
           - $values/cluster/apps/cert-manager/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/cluster/argocd/apps/cilium-resources.yaml
+++ b/cluster/argocd/apps/cilium-resources.yaml
@@ -12,7 +12,7 @@ spec:
   project: kuberseni
   source:
     repoURL: https://github.com/Arsenikki/kuberseni-gitops
-    targetRevision: feat/talos
+    targetRevision: main
     path: cluster/apps/cilium/resources
     directory:
       exclude: "values.yaml"

--- a/cluster/argocd/apps/cilium.yaml
+++ b/cluster/argocd/apps/cilium.yaml
@@ -22,7 +22,7 @@ spec:
         valueFiles:
           - $values/cluster/apps/cilium/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/cluster/argocd/apps/default-homepage.yaml
+++ b/cluster/argocd/apps/default-homepage.yaml
@@ -18,10 +18,10 @@ spec:
         valueFiles:
           - $values/cluster/apps/default/homepage/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/default/homepage
       directory:
         exclude: "values.yaml"

--- a/cluster/argocd/apps/external-dns.yaml
+++ b/cluster/argocd/apps/external-dns.yaml
@@ -18,10 +18,10 @@ spec:
         valueFiles:
           - $values/cluster/apps/external-dns/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/external-dns
       directory:
         exclude: "values.yaml"

--- a/cluster/argocd/apps/generic-device-plugin.yaml
+++ b/cluster/argocd/apps/generic-device-plugin.yaml
@@ -12,7 +12,7 @@ spec:
   project: kuberseni
   sources:
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/generic-device-plugin
   destination:
     server: https://kubernetes.default.svc

--- a/cluster/argocd/apps/home-automation-home-assistant.yaml
+++ b/cluster/argocd/apps/home-automation-home-assistant.yaml
@@ -18,10 +18,10 @@ spec:
         valueFiles:
           - $values/cluster/apps/home-automation/home-assistant/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/home-automation/home-assistant
       directory:
         exclude: "values.yaml"

--- a/cluster/argocd/apps/home-automation-mosquitto.yaml
+++ b/cluster/argocd/apps/home-automation-mosquitto.yaml
@@ -18,10 +18,10 @@ spec:
         valueFiles:
           - $values/cluster/apps/home-automation/mosquitto/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/home-automation/mosquitto
       directory:
         exclude: "values.yaml"

--- a/cluster/argocd/apps/home-automation-node-red.yaml
+++ b/cluster/argocd/apps/home-automation-node-red.yaml
@@ -18,10 +18,10 @@ spec:
         valueFiles:
           - $values/cluster/apps/home-automation/node-red/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/home-automation/node-red
       directory:
         exclude: "values.yaml"

--- a/cluster/argocd/apps/home-automation-philips-bridge.yaml
+++ b/cluster/argocd/apps/home-automation-philips-bridge.yaml
@@ -12,7 +12,7 @@ spec:
   project: kuberseni
   sources:
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/home-automation/philips-bridge
   destination:
     server: https://kubernetes.default.svc

--- a/cluster/argocd/apps/home-automation-zigbee2mqtt.yaml
+++ b/cluster/argocd/apps/home-automation-zigbee2mqtt.yaml
@@ -18,10 +18,10 @@ spec:
         valueFiles:
           - $values/cluster/apps/home-automation/zigbee2mqtt/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/home-automation/zigbee2mqtt
       directory:
         exclude: "values.yaml"

--- a/cluster/argocd/apps/intel-device-plugins-operator.yaml
+++ b/cluster/argocd/apps/intel-device-plugins-operator.yaml
@@ -18,7 +18,7 @@ spec:
         valueFiles:
           - $values/cluster/apps/intel-device-plugins-operator/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/cluster/argocd/apps/intel-gpu-plugin.yaml
+++ b/cluster/argocd/apps/intel-gpu-plugin.yaml
@@ -18,7 +18,7 @@ spec:
         valueFiles:
           - $values/cluster/apps/intel-gpu-plugin/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/cluster/argocd/apps/longhorn-resources.yaml
+++ b/cluster/argocd/apps/longhorn-resources.yaml
@@ -12,7 +12,7 @@ spec:
   project: kuberseni
   source:
     repoURL: https://github.com/Arsenikki/kuberseni-gitops
-    targetRevision: feat/talos
+    targetRevision: main
     path: cluster/apps/longhorn/resources
     directory:
       exclude: "values.yaml"

--- a/cluster/argocd/apps/longhorn.yaml
+++ b/cluster/argocd/apps/longhorn.yaml
@@ -18,7 +18,7 @@ spec:
         valueFiles:
           - $values/cluster/apps/longhorn/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/cluster/argocd/apps/media-bazarr.yaml
+++ b/cluster/argocd/apps/media-bazarr.yaml
@@ -18,10 +18,10 @@ spec:
         valueFiles:
           - $values/cluster/apps/media/bazarr/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/media/bazarr
       directory:
         exclude: "values.yaml"

--- a/cluster/argocd/apps/media-cast-sponsor-skip.yaml
+++ b/cluster/argocd/apps/media-cast-sponsor-skip.yaml
@@ -18,10 +18,10 @@ spec:
         valueFiles:
           - $values/cluster/apps/media/cast-sponsor-skip/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/media/cast-sponsor-skip
       directory:
         exclude: "values.yaml"

--- a/cluster/argocd/apps/media-lidarr.yaml
+++ b/cluster/argocd/apps/media-lidarr.yaml
@@ -18,10 +18,10 @@ spec:
         valueFiles:
           - $values/cluster/apps/media/lidarr/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/media/lidarr
       directory:
         exclude: "values.yaml"

--- a/cluster/argocd/apps/media-overseerr.yaml
+++ b/cluster/argocd/apps/media-overseerr.yaml
@@ -18,10 +18,10 @@ spec:
         valueFiles:
           - $values/cluster/apps/media/overseerr/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/media/overseerr
       directory:
         exclude: "values.yaml"

--- a/cluster/argocd/apps/media-plex.yaml
+++ b/cluster/argocd/apps/media-plex.yaml
@@ -18,10 +18,10 @@ spec:
         valueFiles:
           - $values/cluster/apps/media/plex/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/media/plex
       directory:
         exclude: "values.yaml"

--- a/cluster/argocd/apps/media-prowlarr.yaml
+++ b/cluster/argocd/apps/media-prowlarr.yaml
@@ -18,10 +18,10 @@ spec:
         valueFiles:
           - $values/cluster/apps/media/prowlarr/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/media/prowlarr
       directory:
         exclude: "values.yaml"

--- a/cluster/argocd/apps/media-qbittorrent.yaml
+++ b/cluster/argocd/apps/media-qbittorrent.yaml
@@ -18,10 +18,10 @@ spec:
         valueFiles:
           - $values/cluster/apps/media/qbittorrent/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/media/qbittorrent
       directory:
         exclude: "values.yaml"

--- a/cluster/argocd/apps/media-radarr.yaml
+++ b/cluster/argocd/apps/media-radarr.yaml
@@ -18,10 +18,10 @@ spec:
         valueFiles:
           - $values/cluster/apps/media/radarr/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/media/radarr
       directory:
         exclude: "values.yaml"

--- a/cluster/argocd/apps/media-readarr.yaml
+++ b/cluster/argocd/apps/media-readarr.yaml
@@ -18,10 +18,10 @@ spec:
         valueFiles:
           - $values/cluster/apps/media/readarr/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/media/readarr
       directory:
         exclude: "values.yaml"

--- a/cluster/argocd/apps/media-sonarr.yaml
+++ b/cluster/argocd/apps/media-sonarr.yaml
@@ -18,10 +18,10 @@ spec:
         valueFiles:
           - $values/cluster/apps/media/sonarr/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       path: cluster/apps/media/sonarr
       directory:
         exclude: "values.yaml"

--- a/cluster/argocd/apps/node-feature-discovery.yaml
+++ b/cluster/argocd/apps/node-feature-discovery.yaml
@@ -18,7 +18,7 @@ spec:
         valueFiles:
           - $values/cluster/apps/node-feature-discovery/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/cluster/argocd/apps/traefik-resources.yaml
+++ b/cluster/argocd/apps/traefik-resources.yaml
@@ -12,7 +12,7 @@ spec:
   project: kuberseni
   source:
     repoURL: https://github.com/Arsenikki/kuberseni-gitops
-    targetRevision: feat/talos
+    targetRevision: main
     path: cluster/apps/traefik/resources
     directory:
       exclude: "values.yaml"

--- a/cluster/argocd/apps/traefik.yaml
+++ b/cluster/argocd/apps/traefik.yaml
@@ -18,7 +18,7 @@ spec:
         valueFiles:
           - $values/cluster/apps/traefik/values.yaml
     - repoURL: https://github.com/Arsenikki/kuberseni-gitops
-      targetRevision: feat/talos
+      targetRevision: main
       ref: values
   destination:
     server: https://kubernetes.default.svc

--- a/cluster/argocd/root-app.yaml
+++ b/cluster/argocd/root-app.yaml
@@ -20,7 +20,7 @@ spec:
   project: kuberseni
   source:
     repoURL: https://github.com/Arsenikki/kuberseni-gitops
-    targetRevision: feat/talos
+    targetRevision: main
     path: cluster/argocd
     directory:
       recurse: true


### PR DESCRIPTION
Switches all ArgoCD `targetRevision` references from `feat/talos` to `main`.

Merge immediately after [PR #315](https://github.com/Arsenikki/kuberseni-gitops/pull/315) lands on `main`. At that point `main` has the full Talos config, so ArgoCD switching to track `main` is seamless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Infrastructure and deployment configuration updated for multiple applications and services across the platform. All applications now pull from stable, production-ready configurations to ensure consistent and reliable deployments. These updates improve overall system stability, consistency, and reliability across infrastructure components, services, and the entire platform ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->