### PR TITLE
fix(zigbee2mqtt): add SYS_TTY_CONFIG capability for USB serial access

### DIFF
--- a/cluster/apps/home-automation/zigbee2mqtt/values.yaml
+++ b/cluster/apps/home-automation/zigbee2mqtt/values.yaml
@@ -42,13 +42,12 @@ controllers:
           limits:
             memory: 500Mi
         securityContext:
-          # privileged removed: full privilege was only used to reach the USB
-          # serial dongle. The hostPath CharDevice mount (persistence.usb below)
-          # exposes the device node directly, so no privileged mode is needed.
           allowPrivilegeEscalation: false
           capabilities:
             drop:
               - ALL
+            add:
+              - SYS_TTY_CONFIG
 
 service:
   main:


### PR DESCRIPTION
## Problem

Security hardening in #307 removed `privileged: true` and added `drop: ALL` capabilities. This broke zigbee2mqtt — it's been in CrashLoopBackOff for ~5h with:

```
Operation not permitted, cannot open /dev/serial/by-id/usb-ITEAD_SONOFF_Zigbee_3.0_USB_Dongle_Plus_V2_20231219170448-if00
```

## Fix

Add `SYS_TTY_CONFIG` back. This is the minimum capability needed to configure a TTY/serial device. All other security restrictions (`allowPrivilegeEscalation: false`, `drop: ALL`) are preserved — this is strictly more secure than the pre-hardening `privileged: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)