### PR TITLE
fix(zigbee2mqtt): drop privileged mode via Talos udev rule

### DIFF
--- a/cluster/apps/home-automation/zigbee2mqtt/values.yaml
+++ b/cluster/apps/home-automation/zigbee2mqtt/values.yaml
@@ -56,11 +56,8 @@ controllers:
             memory: 500Mi
         securityContext:
           allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
-            add:
-              - SYS_TTY_CONFIG
+          runAsUser: 0
+          runAsGroup: 20
 
 service:
   main:

--- a/infra/talos/patches/cp01-zigbee-udev.yaml
+++ b/infra/talos/patches/cp01-zigbee-udev.yaml
@@ -1,0 +1,4 @@
+machine:
+  udev:
+    rules:
+      - SUBSYSTEM=="tty", KERNEL=="ttyACM*", MODE="0660", GROUP="20"

--- a/infra/talos/talconfig.yaml
+++ b/infra/talos/talconfig.yaml
@@ -19,6 +19,8 @@ nodes:
     ipAddress: 192.168.1.41
     installDisk: /dev/sda # verify with: talosctl get disks --insecure --nodes 192.168.1.41
     controlPlane: true
+    patches:
+      - "@./patches/cp01-zigbee-udev.yaml"
     networkInterfaces:
       - deviceSelector:
           driver: virtio_net  # machine-type agnostic: works on i440fx (ens18) and q35 (enp*)


### PR DESCRIPTION
## What

Instead of `privileged: true`, properly fix USB serial access by:

1. **Talos udev rule** (`infra/talos/patches/cp01-zigbee-udev.yaml`) — sets `ttyACM*` to `gid=20 mode=0660` on control-plane-01. Applied and confirmed live:
   ```
   crw-rw---- root:20  /dev/ttyACM0  ✅
   ```

2. **zigbee2mqtt securityContext** — `runAsUser: 0` (needed for config PVC) + `runAsGroup: 20` (needed for dongle access). No `privileged: true`, no `drop: ALL`.

## Why Talos needed a udev rule

Talos ships without the standard udev rules that assign serial devices to the `dialout` group. Devices default to `crw------- root:root`, so `supplementalGroups` alone would not have worked. The udev rule was the correct fix.

## Verified

```
NODE           MODE          UID   GID
192.168.1.41   crw-rw----    0     20    /dev/ttyACM0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated the Zigbee2MQTT controller’s container security settings to use explicit runtime user/group IDs and revised capability handling, while keeping privilege escalation disabled.
* **Infrastructure**
  * Added Talos udev rules to set permissions for USB serial (ttyACM) devices, ensuring access to required Zigbee hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->