### PR TITLE
fix(zigbee2mqtt): restore SYS_TTY_CONFIG capability for serial port access

### DIFF
--- a/cluster/apps/home-automation/zigbee2mqtt/values.yaml
+++ b/cluster/apps/home-automation/zigbee2mqtt/values.yaml
@@ -58,6 +58,9 @@ controllers:
           allowPrivilegeEscalation: false
           runAsUser: 0
           runAsGroup: 20
+          capabilities:
+            add:
+              - SYS_TTY_CONFIG
 
 service:
   main:


### PR DESCRIPTION
Udev rule (GROUP=20 MODE=0660 on ttyACM*) alone is insufficient on Talos — the `EPERM` when opening the serial device is a **capability** issue, not a file permission issue. `SYS_TTY_CONFIG` is required for TTY `ioctl` initialization even when running as root.

The udev rule from #329 is still valid and kept — it ensures the group has access. But `SYS_TTY_CONFIG` also needs to be present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)