### PR TITLE
fix(zigbee2mqtt): revert securityContext to known-working drop:ALL + SYS_TTY_CONFIG

### DIFF
--- a/cluster/apps/home-automation/zigbee2mqtt/values.yaml
+++ b/cluster/apps/home-automation/zigbee2mqtt/values.yaml
@@ -56,9 +56,9 @@ controllers:
             memory: 500Mi
         securityContext:
           allowPrivilegeEscalation: false
-          runAsUser: 0
-          runAsGroup: 20
           capabilities:
+            drop:
+              - ALL
             add:
               - SYS_TTY_CONFIG
 


### PR DESCRIPTION
PR #329 changed the security context by adding `runAsUser: 0` / `runAsGroup: 20` and relying solely on the udev rule for device access. This broke serial port access.

Restoring the exact config from #328 which was the last known-working state:

```yaml
securityContext:
  allowPrivilegeEscalation: false
  capabilities:
    drop:
      - ALL
    add:
      - SYS_TTY_CONFIG
```

The udev rule from #329 (`cp01-zigbee-udev.yaml`) is kept — it's harmless and provides defence-in-depth on device permissions. The `runAsUser: 0` / `runAsGroup: 20` lines are removed as they weren't in the working config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)