### PR TITLE
fix(zigbee2mqtt): use privileged mode for USB device cgroup access

### DIFF
--- a/cluster/apps/home-automation/zigbee2mqtt/values.yaml
+++ b/cluster/apps/home-automation/zigbee2mqtt/values.yaml
@@ -55,12 +55,7 @@ controllers:
           limits:
             memory: 500Mi
         securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
-            add:
-              - SYS_TTY_CONFIG
+          privileged: true
 
 service:
   main:


### PR DESCRIPTION
Non-privileged approaches (SYS_TTY_CONFIG capability, udev rule, drop:ALL) all produce `EPERM: Operation not permitted, cannot open /dev/serial/by-id/...`.

Root cause: the cgroup device controller doesn't correctly whitelist device major:minor numbers when the `hostPath` is a `by-id` symlink rather than a direct device path (e.g. `/dev/ttyACM0`). Kubernetes resolves the volume mount but the OCI runtime doesn't add the device to the cgroup allowlist via the symlink.

`privileged: true` bypasses the cgroup device whitelist entirely — the same approach used by gluetun on this cluster. The USB dongle is on a single node (`control-plane-01`) pinned via `nodeSelector`, so the blast radius is contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)