### PR TITLE
feat(cilium): upgrade 1.17.2 → 1.18.10 (step 1 of 2)

### DIFF
--- a/cluster/argocd/apps/cilium.yaml
+++ b/cluster/argocd/apps/cilium.yaml
@@ -15,9 +15,9 @@ spec:
   sources:
     - repoURL: https://helm.cilium.io
       chart: cilium
-      # Rolled back from 1.19.4 — the upgrade broke cross-node routing on CP-01
-      # (different L2 bridge vmbr2 vs vmbr0). Investigate before re-upgrading.
-      targetRevision: 1.17.2
+      # Upgrading step-by-step: 1.17.2 → 1.18.10 → 1.19.x
+      # 1.19.4 previously broke cross-node routing on CP-01 (vmbr2 vs vmbr0 bridge mismatch).
+      targetRevision: 1.18.10
       helm:
         valueFiles:
           - $values/cluster/apps/cilium/values.yaml


### PR DESCRIPTION
## Summary

- Bumps Cilium from 1.17.2 → 1.18.10 as the first hop toward 1.19.x
- 1.19.4 previously broke cross-node routing on CP-01 (different Proxmox bridge: vmbr2 vs vmbr0 on CP-02/CP-03)
- Stepping through minor versions to isolate where any regression appears

## Baseline (Cilium 1.17.2 — verified before this PR)

All cross-node pod pings 0% packet loss, including the critical CP-01 ↔ CP-02/CP-03 paths. ArgoCD `argocd-repo-server` ClusterIP reachable from CP-01 (the exact service that failed on 1.19.4).

## Test plan

- [ ] ArgoCD syncs successfully after merge
- [ ] Run netcheck DaemonSet connectivity matrix (CP-01 ↔ all nodes, 0% loss)
- [ ] Verify `argocd-repo-server` ClusterIP reachable from CP-01
- [ ] If green: open follow-up PR for 1.18.10 → 1.19.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Cilium networking component to version 1.18.10, with updated documentation for the upgrade path and known compatibility notes for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->