### PR TITLE
feat(notifications): ntfy + ArgoCD self-management

### DIFF
--- a/cluster/apps/home-automation/k8s-event-exporter/configmap.yaml
+++ b/cluster/apps/home-automation/k8s-event-exporter/configmap.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8s-event-exporter-config
+  namespace: home-automation
+data:
+  config.yaml: |
+    logLevel: error
+    logFormat: json
+    maxEventAgeSeconds: 10
+    route:
+      routes:
+        - match:
+            - type: Warning
+              reason:
+                - BackOff
+                - OOMKilling
+                - Failed
+                - FailedMount
+                - FailedScheduling
+                - Evicted
+                - NodeNotReady
+                - Killing
+          drop:
+            - namespace: kube-system
+            - namespace: kube-node-lease
+          sink:
+            - ref: ntfy
+    sinks:
+      - name: ntfy
+        webhook:
+          endpoint: http://ntfy.home-automation.svc.cluster.local
+          headers:
+            Content-Type: application/json
+          layout:
+            topic: k8s-events
+            title: "{{.Reason}}: {{.InvolvedObject.Namespace}}/{{.InvolvedObject.Name}}"
+            message: "{{.Message}}"
+            priority: 3
+            tags:
+              - warning

--- a/cluster/apps/home-automation/k8s-event-exporter/deployment.yaml
+++ b/cluster/apps/home-automation/k8s-event-exporter/deployment.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8s-event-exporter
+  namespace: home-automation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: k8s-event-exporter
+  template:
+    metadata:
+      labels:
+        app: k8s-event-exporter
+    spec:
+      serviceAccountName: k8s-event-exporter
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+        - name: k8s-event-exporter
+          image: ghcr.io/resmoio/kubernetes-event-exporter:v1.7
+          args:
+            - -conf=/etc/event-exporter/config.yaml
+          resources:
+            requests:
+              cpu: 20m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/event-exporter
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: k8s-event-exporter-config

--- a/cluster/apps/home-automation/k8s-event-exporter/rbac.yaml
+++ b/cluster/apps/home-automation/k8s-event-exporter/rbac.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8s-event-exporter
+  namespace: home-automation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8s-event-exporter
+rules:
+  - apiGroups: [""]
+    resources: [events, namespaces, nodes, pods]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-event-exporter
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8s-event-exporter
+subjects:
+  - kind: ServiceAccount
+    name: k8s-event-exporter
+    namespace: home-automation

--- a/cluster/apps/home-automation/ntfy/configmap.yaml
+++ b/cluster/apps/home-automation/ntfy/configmap.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ntfy-config
+  namespace: home-automation
+data:
+  server.yml: |
+    base-url: https://ntfy.arsenikki.casa
+    cache-file: /var/lib/ntfy/cache.db
+    cache-duration: 12h
+    # Allow all reads and writes without authentication.
+    # ntfy is LAN/VPN-only; no Authentik on the ingress so mobile apps
+    # can subscribe directly.
+    auth-default-access: read-write
+    behind-proxy: true
+    log-level: warn

--- a/cluster/apps/home-automation/ntfy/pvc.yaml
+++ b/cluster/apps/home-automation/ntfy/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ntfy-data
+  namespace: home-automation
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 1Gi

--- a/cluster/apps/home-automation/ntfy/values.yaml
+++ b/cluster/apps/home-automation/ntfy/values.yaml
@@ -1,0 +1,53 @@
+---
+image:
+  repository: binwiederhier/ntfy
+  tag: v2.11.0
+
+args:
+  - serve
+  - --config
+  - /etc/ntfy/server.yml
+
+env:
+  TZ: Europe/London
+
+service:
+  main:
+    ports:
+      http:
+        port: 80
+
+ingress:
+  main:
+    enabled: true
+    annotations:
+      kubernetes.io/tls-acme: "true"
+      # Intentionally no Authentik — ntfy mobile app needs direct API access
+    hosts:
+      - host: ntfy.arsenikki.casa
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: ntfy-tls
+        hosts:
+          - ntfy.arsenikki.casa
+
+persistence:
+  data:
+    enabled: true
+    mountPath: /var/lib/ntfy
+    existingClaim: ntfy-data
+  config:
+    enabled: true
+    type: configMap
+    name: ntfy-config
+    mountPath: /etc/ntfy
+    readOnly: true
+
+resources:
+  requests:
+    cpu: 20m
+    memory: 64Mi
+  limits:
+    memory: 128Mi

--- a/cluster/argocd/apps/argocd.yaml
+++ b/cluster/argocd/apps/argocd.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: kuberseni
+  sources:
+    - repoURL: https://argoproj.github.io/argo-helm
+      chart: argo-cd
+      targetRevision: 9.5.19
+      helm:
+        valueFiles:
+          - $values/cluster/bootstrap/argocd/values.yaml
+    - repoURL: https://github.com/Arsenikki/kuberseni-gitops
+      targetRevision: main
+      ref: values
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/cluster/argocd/apps/home-automation-k8s-event-exporter.yaml
+++ b/cluster/argocd/apps/home-automation-k8s-event-exporter.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: k8s-event-exporter
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: kuberseni
+  source:
+    repoURL: https://github.com/Arsenikki/kuberseni-gitops
+    targetRevision: main
+    path: cluster/apps/home-automation/k8s-event-exporter
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: home-automation
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/cluster/argocd/apps/home-automation-ntfy.yaml
+++ b/cluster/argocd/apps/home-automation-ntfy.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ntfy
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: kuberseni
+  sources:
+    - repoURL: https://bjw-s-labs.github.io/helm-charts
+      chart: app-template
+      targetRevision: 1.5.1
+      helm:
+        valueFiles:
+          - $values/cluster/apps/home-automation/ntfy/values.yaml
+    - repoURL: https://github.com/Arsenikki/kuberseni-gitops
+      targetRevision: main
+      ref: values
+    - repoURL: https://github.com/Arsenikki/kuberseni-gitops
+      targetRevision: main
+      path: cluster/apps/home-automation/ntfy
+      directory:
+        exclude: "values.yaml"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: home-automation
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/cluster/argocd/projects/kuberseni.yaml
+++ b/cluster/argocd/projects/kuberseni.yaml
@@ -20,6 +20,7 @@ spec:
     - https://charts.goauthentik.io
     - https://charts.rook.io/release
     - https://democratic-csi.github.io/charts
+    - https://argoproj.github.io/argo-helm
     - https://bjw-s-labs.github.io/helm-charts
     - https://charts.external-secrets.io
     - https://kubernetes-sigs.github.io/external-dns/

--- a/cluster/bootstrap/argocd/values.yaml
+++ b/cluster/bootstrap/argocd/values.yaml
@@ -31,6 +31,82 @@ server:
     - key: node-role.kubernetes.io/control-plane
       operator: Exists
 
+notifications:
+  enabled: true
+  argocdUrl: https://argocd.arsenikki.casa
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: ""
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+  cm:
+    create: true
+  secret:
+    create: true
+    items: {}
+  notifiers:
+    "service.webhook.ntfy": |
+      url: http://ntfy.home-automation.svc.cluster.local
+      headers:
+        - name: Content-Type
+          value: application/json
+  templates:
+    "template.app-sync-succeeded": |
+      webhook:
+        ntfy:
+          method: POST
+          path: /
+          body: |
+            {
+              "topic": "argocd",
+              "title": "Synced: {{.app.metadata.name}}",
+              "message": "{{.app.metadata.name}} synced successfully.",
+              "tags": ["white_check_mark"],
+              "priority": 2
+            }
+    "template.app-sync-failed": |
+      webhook:
+        ntfy:
+          method: POST
+          path: /
+          body: |
+            {
+              "topic": "argocd",
+              "title": "Sync Failed: {{.app.metadata.name}}",
+              "message": "{{.app.metadata.name}} sync failed.\n\n{{.app.status.operationState.message}}",
+              "tags": ["x"],
+              "priority": 4
+            }
+    "template.app-health-degraded": |
+      webhook:
+        ntfy:
+          method: POST
+          path: /
+          body: |
+            {
+              "topic": "argocd",
+              "title": "Degraded: {{.app.metadata.name}}",
+              "message": "{{.app.metadata.name}} health is Degraded.",
+              "tags": ["warning"],
+              "priority": 4
+            }
+  triggers:
+    "trigger.on-sync-succeeded": |
+      - when: app.status.operationState.phase in ['Succeeded'] and app.status.health.status == 'Healthy'
+        send: [app-sync-succeeded]
+    "trigger.on-sync-failed": |
+      - when: app.status.operationState.phase in ['Error', 'Failed']
+        send: [app-sync-failed]
+    "trigger.on-health-degraded": |
+      - when: app.status.health.status == 'Degraded'
+        send: [app-health-degraded]
+  subscriptions:
+    - recipients:
+        - webhook:ntfy
+      triggers:
+        - on-sync-failed
+        - on-health-degraded
+
 # Run ArgoCD components on control-plane nodes
 controller:
   nodeSelector:

--- a/infra/scripts/bootstrap-cluster.sh
+++ b/infra/scripts/bootstrap-cluster.sh
@@ -61,11 +61,15 @@ kube wait --for=condition=Ready nodes --all --timeout=5m
 echo "  all nodes Ready ✓"
 
 # ── ArgoCD ────────────────────────────────────────────────────────────────────
+# Version is sourced from the ArgoCD Application definition to avoid duplication.
+ARGOCD_VERSION=$(yq '.spec.sources[] | select(.chart == "argo-cd") | .targetRevision' \
+  "$REPO_ROOT/cluster/argocd/apps/argocd.yaml")
 echo ""
-echo "→ Installing ArgoCD..."
+echo "→ Installing ArgoCD $ARGOCD_VERSION (from cluster/argocd/apps/argocd.yaml)..."
 helm upgrade --install argocd argo/argo-cd \
   --kube-context "$CONTEXT" \
   --namespace argocd --create-namespace \
+  --version "$ARGOCD_VERSION" \
   --wait \
   -f "$REPO_ROOT/cluster/bootstrap/argocd/values.yaml"
 echo "  ArgoCD installed ✓"


### PR DESCRIPTION
## Summary

- Deploy **ntfy** (`ntfy.arsenikki.casa`) — no Authentik so the mobile app can subscribe directly; open read-write access (LAN/VPN only)
- Deploy **k8s-event-exporter** watching `Warning` events (BackOff, OOMKilling, FailedMount, FailedScheduling, Evicted, NodeNotReady) and POSTing to ntfy `k8s-events` topic
- Enable **ArgoCD notifications controller** with ntfy webhook; global subscriptions for `on-sync-failed` and `on-health-degraded` across all apps
- Add **ArgoCD self-managed Application** so changes to `cluster/bootstrap/argocd/values.yaml` apply via GitOps instead of requiring a manual `helm upgrade`
- Bootstrap script now reads ArgoCD chart version from `cluster/argocd/apps/argocd.yaml` (same single-source-of-truth pattern as Cilium)

## ntfy topics

| Topic | Source |
|---|---|
| `argocd` | ArgoCD notifications controller |
| `k8s-events` | k8s-event-exporter (pod restarts, OOM, etc.) |
| `media` | Configure manually in Sonarr/Radarr UI |
| `downloads` | Configure manually in qBittorrent UI |

## Manual steps after merge

**Sonarr** — Settings → Connect → + → Webhook:
- URL: `http://ntfy.home-automation.svc.cluster.local/media`
- Method: POST, Header: `Title: New Episode: {Series.Title} S{season:00}E{episode:00}`

**Radarr** — same path:
- URL: `http://ntfy.home-automation.svc.cluster.local/media`, Header: `Title: New Movie: {Movie.Title}`

**qBittorrent** — Settings → Downloads → Run on completion:
```
curl -d "Complete: %N" -H "Title: Download finished" http://ntfy.home-automation.svc.cluster.local/downloads
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)