### PR TITLE
feat(cilium): upgrade 1.18.10 → 1.19.4 (step 2 of 2)

### DIFF
--- a/cluster/argocd/apps/cilium.yaml
+++ b/cluster/argocd/apps/cilium.yaml
@@ -17,7 +17,8 @@ spec:
       chart: cilium
       # Upgrading step-by-step: 1.17.2 → 1.18.10 → 1.19.x
       # 1.19.4 previously broke cross-node routing on CP-01 (vmbr2 vs vmbr0 bridge mismatch).
-      targetRevision: 1.18.10
+      # Re-attempting with explicit devices/directRoutingDevice already set in values.yaml.
+      targetRevision: 1.19.4
       helm:
         valueFiles:
           - $values/cluster/apps/cilium/values.yaml

--- a/cluster/argocd/apps/cilium.yaml
+++ b/cluster/argocd/apps/cilium.yaml
@@ -15,9 +15,9 @@ spec:
   sources:
     - repoURL: https://helm.cilium.io
       chart: cilium
-      # Rolled back from 1.19.4 — the upgrade broke cross-node routing on CP-01
-      # (different L2 bridge vmbr2 vs vmbr0). Investigate before re-upgrading.
-      targetRevision: 1.17.2
+      # Upgrading step-by-step: 1.17.2 → 1.18.10 → 1.19.x
+      # 1.19.4 previously broke cross-node routing on CP-01 (vmbr2 vs vmbr0 bridge mismatch).
+      targetRevision: 1.18.10
       helm:
         valueFiles:
           - $values/cluster/apps/cilium/values.yaml


### PR DESCRIPTION
## Summary

- Bumps Cilium 1.18.10 → 1.19.4, completing the two-step upgrade from 1.17.2
- Previous attempt at 1.19.4 broke cross-node routing on CP-01 (vmbr2 vs vmbr0 bridge mismatch); root cause was missing explicit `devices`/`directRoutingDevice` config — both are now set in `values.yaml`

## Connectivity verified at each step

| Version | CP-01 ↔ all nodes | argocd-repo-server ClusterIP |
|---|---|---|
| 1.17.2 (baseline) | ✅ 0% loss | ✅ PASS |
| 1.18.10 | ✅ 0% loss | ✅ PASS |

## Test plan

- [ ] ArgoCD syncs successfully after merge
- [ ] Run netcheck DaemonSet connectivity matrix (CP-01 ↔ all nodes, 0% loss)
- [ ] Verify `argocd-repo-server` ClusterIP (10.103.100.120:8081) reachable from CP-01
- [ ] If broken: rollback to 1.18.10 and investigate routing mode (`routingMode: tunnel`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)