### PR TITLE
feat(cilium): enable WireGuard node-to-node encryption

### DIFF
--- a/cluster/apps/cilium/values.yaml
+++ b/cluster/apps/cilium/values.yaml
@@ -15,6 +15,11 @@ dnsProxy:
 devices: "ens+"
 directRoutingDevice: "ens18"
 
+encryption:
+  enabled: true
+  type: wireguard
+  nodeEncryption: true
+
 l2announcements:
   enabled: true
   # Values are high due to https://github.com/cilium/cilium/issues/26586


### PR DESCRIPTION
## Summary

- Enables Cilium WireGuard encryption for all pod-to-pod and node-to-node traffic
- Talos ships with WireGuard built into the kernel — no `SYS_MODULE` needed
- `NET_ADMIN` capability already present in `ciliumAgent` securityContext

## Config added

```yaml
encryption:
  enabled: true
  type: wireguard
  nodeEncryption: true
```

## Prerequisites met

- Cilium upgraded to 1.19.4 (previous PR) — WireGuard support is stable in this version
- Connectivity verified at 1.17.2, 1.18.10, and 1.19.4 before this change

## Test plan

- [ ] ArgoCD syncs successfully after merge
- [ ] Run netcheck DaemonSet connectivity matrix (CP-01 ↔ all nodes, 0% loss)
- [ ] Verify `argocd-repo-server` ClusterIP (10.103.100.120:8081) reachable from CP-01
- [ ] Confirm encryption active: `kubectl -n kube-system exec -it ds/cilium -- cilium encrypt status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)