### PR TITLE
fix(k8s-event-exporter): use regex string for reason field

### DIFF
--- a/cluster/apps/home-automation/k8s-event-exporter/configmap.yaml
+++ b/cluster/apps/home-automation/k8s-event-exporter/configmap.yaml
@@ -13,15 +13,7 @@ data:
       routes:
         - match:
             - type: Warning
-              reason:
-                - BackOff
-                - OOMKilling
-                - Failed
-                - FailedMount
-                - FailedScheduling
-                - Evicted
-                - NodeNotReady
-                - Killing
+              reason: "BackOff|OOMKilling|Failed|FailedMount|FailedScheduling|Evicted|NodeNotReady|Killing"
           drop:
             - namespace: kube-system
             - namespace: kube-node-lease


### PR DESCRIPTION
[#334](https://github.com/Arsenikki/kuberseni-gitops/pull/334)

k8s-event-exporter v1.7 expects `reason` as a string (regex pattern), not a YAML list. The list caused a fatal parse error at startup, leaving the pod in a crash loop.

Converts the multi-item list to a single `|`-delimited regex string.