### PR TITLE
feat(tautulli): deploy Tautulli with CasaBot Telegram notifications

### DIFF
--- a/cluster/apps/media/tautulli/externalsecret.yaml
+++ b/cluster/apps/media/tautulli/externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# CasaBot Telegram credentials for Tautulli notification agent.
+# 1Password item: "CasaBot (Telegram)" (vault: homelab)
+#   fields: credential (bot token), chat_id
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: casabot-credentials
+  namespace: media
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: casabot-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: TELEGRAM_BOT_TOKEN
+      remoteRef:
+        key: "CasaBot (Telegram)"
+        property: credential
+    - secretKey: TELEGRAM_CHAT_ID
+      remoteRef:
+        key: "CasaBot (Telegram)"
+        property: chat_id

--- a/cluster/apps/media/tautulli/pvc.yaml
+++ b/cluster/apps/media/tautulli/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tautulli-config
+  namespace: media
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: longhorn

--- a/cluster/apps/media/tautulli/values.yaml
+++ b/cluster/apps/media/tautulli/values.yaml
@@ -1,7 +1,7 @@
 ---
 image:
   repository: ghcr.io/home-operations/tautulli
-  tag: 2.15.2
+  tag: 2.17.1
 
 env:
   TZ: Europe/London

--- a/cluster/apps/media/tautulli/values.yaml
+++ b/cluster/apps/media/tautulli/values.yaml
@@ -1,0 +1,47 @@
+---
+image:
+  repository: ghcr.io/home-operations/tautulli
+  tag: 2.15.2
+
+env:
+  TZ: Europe/London
+
+service:
+  main:
+    ports:
+      http:
+        port: 8181
+
+ingress:
+  main:
+    enabled: true
+    annotations:
+      kubernetes.io/tls-acme: "true"
+      traefik.ingress.kubernetes.io/router.middlewares: "authentik-forward-auth@kubernetescrd"
+    hosts:
+      - host: tautulli.arsenikki.casa
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - secretName: tautulli-tls
+        hosts:
+          - tautulli.arsenikki.casa
+
+podSecurityContext:
+  runAsUser: 568
+  runAsGroup: 568
+  fsGroup: 568
+  fsGroupChangePolicy: OnRootMismatch
+
+persistence:
+  config:
+    enabled: true
+    existingClaim: tautulli-config
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 256Mi
+  limits:
+    memory: 512Mi

--- a/cluster/argocd/apps/media-tautulli.yaml
+++ b/cluster/argocd/apps/media-tautulli.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tautulli
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: kuberseni
+  sources:
+    - repoURL: https://bjw-s-labs.github.io/helm-charts
+      chart: app-template
+      targetRevision: 1.5.1
+      helm:
+        valueFiles:
+          - $values/cluster/apps/media/tautulli/values.yaml
+    - repoURL: https://github.com/Arsenikki/kuberseni-gitops
+      targetRevision: main
+      ref: values
+    - repoURL: https://github.com/Arsenikki/kuberseni-gitops
+      targetRevision: main
+      path: cluster/apps/media/tautulli
+      directory:
+        exclude: "values.yaml"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: media
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Deploy Tautulli for Plex monitoring/analytics, wired with CasaBot Telegram credentials.

## Changes
- Tautulli deployment via bjw-s app-template at `tautulli.arsenikki.casa` (Authentik protected)
- `ExternalSecret` pulling CasaBot bot token + chat_id from 1Password `homelab` vault
- 1Gi Longhorn PVC for config persistence
- ArgoCD app at sync-wave 5

## Post-merge
Once Tautulli is running, Telegram notification agent will be configured via API (notifier_id=23).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tautulli media server application with persistent storage configuration, secure web access via ingress, and Telegram bot integration for notifications.

* **Improvements**
  * Updated event filtering logic in the Kubernetes event exporter for enhanced pattern-based matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->