### PR TITLE
feat(cilium): bandwidth manager, maglev LB, eBPF host routing

### DIFF
--- a/cluster/apps/cilium/values.yaml
+++ b/cluster/apps/cilium/values.yaml
@@ -20,6 +20,15 @@ encryption:
   type: wireguard
   nodeEncryption: true
 
+bandwidthManager:
+  enabled: true
+
+loadBalancer:
+  algorithm: maglev
+
+bpf:
+  hostLegacyRouting: false
+
 l2announcements:
   enabled: true
   # Values are high due to https://github.com/cilium/cilium/issues/26586

--- a/cluster/apps/cilium/values.yaml
+++ b/cluster/apps/cilium/values.yaml
@@ -15,6 +15,11 @@ dnsProxy:
 devices: "ens+"
 directRoutingDevice: "ens18"
 
+encryption:
+  enabled: true
+  type: wireguard
+  nodeEncryption: true
+
 l2announcements:
   enabled: true
   # Values are high due to https://github.com/cilium/cilium/issues/26586


### PR DESCRIPTION
## Summary

Three eBPF performance improvements on top of the 1.19.4 + WireGuard baseline:

- **Bandwidth Manager** — eBPF-based fair queuing and rate limiting between pods; prevents one workload from starving others on shared nodes
- **Maglev LB** — consistent-hash load balancing algorithm; same client always routes to the same backend, better for stateful connections (Plex, qBittorrent, etc.)
- **eBPF host routing** (`bpf.hostLegacyRouting: false`) — bypasses iptables for host-level traffic, pure eBPF path end-to-end

## No compatibility concerns

All three are stable in 1.19.4, compatible with WireGuard encryption, and have no known conflicts with the current L2 announcement + kubeProxyReplacement setup.

## Test plan

- [ ] ArgoCD syncs successfully
- [ ] Run netcheck connectivity matrix (0% loss, CP-01 ↔ all nodes)
- [ ] Verify `argocd-repo-server` ClusterIP reachable from CP-01
- [ ] Confirm bandwidth manager active: `kubectl -n kube-system exec ds/cilium -- cilium bpf bandwidth list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)