### PR TITLE
feat: captain-core v0.6.0 Mini App

### DIFF
--- a/cluster/apps/captain-core/deployment.yaml
+++ b/cluster/apps/captain-core/deployment.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -18,7 +17,7 @@ spec:
         - name: ghcr-credentials
       containers:
         - name: bot
-          image: ghcr.io/arsenikki/captain-core:v0.5.0
+          image: ghcr.io/arsenikki/captain-core:v0.6.0
           imagePullPolicy: IfNotPresent
           command: [".venv/bin/python", "bot.py"]
           env:
@@ -86,6 +85,10 @@ spec:
                   name: captain-core-credentials
                   key: gcal-refresh-token
                   optional: true
+          ports:
+            - containerPort: 8000
+              name: http
+              protocol: TCP
           resources:
             requests:
               cpu: 100m

--- a/cluster/apps/captain-core/ingress-app.yaml
+++ b/cluster/apps/captain-core/ingress-app.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -5,6 +6,7 @@ metadata:
   namespace: captain-core
   annotations:
     kubernetes.io/tls-acme: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     external-dns/is-public: "true"
 spec:
   ingressClassName: traefik

--- a/cluster/apps/captain-core/ingress-app.yaml
+++ b/cluster/apps/captain-core/ingress-app.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: captain-core-app
+  namespace: captain-core
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    external-dns/is-public: "true"
+spec:
+  ingressClassName: traefik
+  rules:
+    - host: captain-core.arsenikki.casa
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: captain-core-app
+                port:
+                  number: 8000
+  tls:
+    - hosts:
+        - captain-core.arsenikki.casa
+      secretName: captain-core-app-tls

--- a/cluster/apps/captain-core/service-app.yaml
+++ b/cluster/apps/captain-core/service-app.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/cluster/apps/captain-core/service-app.yaml
+++ b/cluster/apps/captain-core/service-app.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: captain-core-app
+  namespace: captain-core
+spec:
+  type: ClusterIP
+  selector:
+    app: captain-core-bot
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8000


### PR DESCRIPTION
Bumps captain-core to v0.6.0, adds ClusterIP service and Traefik ingress for captain-core.arsenikki.casa.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image to version 0.6.0 with port exposure configuration

* **Infrastructure Updates**
  * Added TLS-secured HTTPS domain routing
  * Enabled automatic certificate provisioning
  * Configured public DNS service discovery for external access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->