### PR TITLE
fix(k8s-event-exporter): expand RBAC for metadata enrichment, revert maxEventAgeSeconds

### DIFF
--- a/cluster/apps/home-automation/k8s-event-exporter/configmap.yaml
+++ b/cluster/apps/home-automation/k8s-event-exporter/configmap.yaml
@@ -8,7 +8,7 @@ data:
   config.yaml: |
     logLevel: error
     logFormat: json
-    maxEventAgeSeconds: 30
+    maxEventAgeSeconds: 120
     route:
       routes:
         - match:

--- a/cluster/apps/home-automation/k8s-event-exporter/configmap.yaml
+++ b/cluster/apps/home-automation/k8s-event-exporter/configmap.yaml
@@ -8,7 +8,7 @@ data:
   config.yaml: |
     logLevel: error
     logFormat: json
-    maxEventAgeSeconds: 120
+    maxEventAgeSeconds: 30
     route:
       routes:
         - match:

--- a/cluster/apps/home-automation/k8s-event-exporter/rbac.yaml
+++ b/cluster/apps/home-automation/k8s-event-exporter/rbac.yaml
@@ -11,8 +11,20 @@ metadata:
   name: k8s-event-exporter
 rules:
   - apiGroups: [""]
-    resources: [events, namespaces, nodes, pods]
+    resources: [events, namespaces, nodes, pods, replicationcontrollers]
     verbs: [get, list, watch]
+  - apiGroups: ["apps"]
+    resources: [deployments, replicasets, statefulsets, daemonsets]
+    verbs: [get]
+  - apiGroups: ["batch"]
+    resources: [jobs, cronjobs]
+    verbs: [get]
+  - apiGroups: ["argoproj.io"]
+    resources: [applications]
+    verbs: [get]
+  - apiGroups: ["longhorn.io"]
+    resources: [volumes]
+    verbs: [get]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
The exporter was flooding the API with forbidden errors trying to enrich events for objects it couldn't access (ArgoCD apps, Longhorn volumes, Jobs, Deployments). This caused heavy client-side throttling that delayed event watch delivery past `maxEventAgeSeconds`, silently dropping all notifications.

## Changes
- Expand ClusterRole with `get` on `apps`, `batch`, `argoproj.io`, `longhorn.io` resources
- Revert `maxEventAgeSeconds` 120 → 30s now that throttling is fixed

## Result
Enrichment works properly and watch delivery is no longer delayed by throttling.