### PR TITLE
chore: bump captain-core to v0.10.3

### DIFF
--- a/cluster/apps/captain-core/deployment.yaml
+++ b/cluster/apps/captain-core/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         - name: ghcr-credentials
       containers:
         - name: bot
-          image: ghcr.io/arsenikki/captain-core:v0.10.2
+          image: ghcr.io/arsenikki/captain-core:v0.10.3
           imagePullPolicy: IfNotPresent
           command: [".venv/bin/python", "bot.py"]
           env:


### PR DESCRIPTION
88px top clearance so Telegram Close button doesn't overlap the date carousel.