### PR TITLE
chore: bump captain-core to v0.11.0

### DIFF
--- a/cluster/apps/captain-core/deployment.yaml
+++ b/cluster/apps/captain-core/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         - name: ghcr-credentials
       containers:
         - name: bot
-          image: ghcr.io/arsenikki/captain-core:v0.10.4
+          image: ghcr.io/arsenikki/captain-core:v0.11.0
           imagePullPolicy: IfNotPresent
           command: [".venv/bin/python", "bot.py"]
           env:


### PR DESCRIPTION
Cancel via Mini App now deletes the Google Calendar event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated captain-core service to version v0.11.0 from v0.10.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->