### PR TITLE
chore: bump captain-core to v0.11.1

### DIFF
--- a/cluster/apps/captain-core/deployment.yaml
+++ b/cluster/apps/captain-core/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         - name: ghcr-credentials
       containers:
         - name: bot
-          image: ghcr.io/arsenikki/captain-core:v0.11.0
+          image: ghcr.io/arsenikki/captain-core:v0.11.1
           imagePullPolicy: IfNotPresent
           command: [".venv/bin/python", "bot.py"]
           env:


### PR DESCRIPTION
Cancel from Classes tab now also deletes Google Calendar event.