### PR TITLE
fix(monitoring): SeaweedFS s3 logs emptyDir + Mimir classic architecture

### DIFF
--- a/cluster/apps/monitoring/mimir/values.yaml
+++ b/cluster/apps/monitoring/mimir/values.yaml
@@ -30,6 +30,12 @@ mimir:
     multitenancy_enabled: false
     no_auth_tenant: homelab
 
+    # Chart 6.x defaults to the Kafka-based ingest-storage architecture, which fails
+    # with "Kafka address has not been configured" when kafka.enabled=false. Force the
+    # classic architecture: no Kafka, push to ingesters over gRPC.
+    ingest_storage:
+      enabled: false
+
     common:
       storage:
         backend: s3
@@ -51,7 +57,9 @@ mimir:
         bucket_name: mimir-alertmanager
 
     # Single ingester → RF must be 1, else writes are rejected.
+    # push_grpc re-enabled (chart disables it for the ingest-storage architecture).
     ingester:
+      push_grpc_method_enabled: true
       ring:
         replication_factor: 1
 

--- a/cluster/apps/monitoring/seaweedfs/values.yaml
+++ b/cluster/apps/monitoring/seaweedfs/values.yaml
@@ -41,6 +41,9 @@ s3:
   enabled: true
   replicas: 1
   port: 8333
+  # Logs default to hostPath /storage — read-only on Talos. Use emptyDir.
+  logs:
+    type: "emptyDir"
   enableAuth: true
   # JSON identity config templated from 1Password by ESO (see externalsecrets.yaml).
   existingConfigSecret: "seaweedfs-s3-config"


### PR DESCRIPTION
First live-deploy iteration fixes (stack was deploying via ArgoCD on #396).

- **SeaweedFS s3**: logged to hostPath `/storage` (read-only on Talos) → `CreateContainerError`. Set `s3.logs` to emptyDir (master/volume/filer already were).
- **Mimir**: chart 6.x defaults to the Kafka ingest-storage architecture; with `kafka.enabled=false` all components crashed (`Kafka address has not been configured`). Forced classic mode: `ingest_storage.enabled=false` + `ingester.push_grpc_method_enabled=true`.

Both `helm template`-validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Updated Grafana Mimir monitoring service configuration
* Modified SeaweedFS storage settings for containerized deployment environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->