### PR TITLE
feat(monitoring): Proxmox VE exporter for hypervisor + VM-state metrics

### DIFF
--- a/cluster/apps/monitoring/pve-exporter/deployment.yaml
+++ b/cluster/apps/monitoring/pve-exporter/deployment.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pve-exporter
+  namespace: monitoring
+  labels:
+    app: pve-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: pve-exporter
+  template:
+    metadata:
+      labels:
+        app: pve-exporter
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: pve-exporter
+          image: prompve/prometheus-pve-exporter:3.9.0
+          ports:
+            - name: metrics
+              containerPort: 9221
+          env:
+            # Don't verify the Proxmox self-signed API cert.
+            - name: PVE_VERIFY_SSL
+              value: "false"
+          # PVE_USER / PVE_TOKEN_NAME / PVE_TOKEN_VALUE from the ESO secret.
+          envFrom:
+            - secretRef:
+                name: pve-exporter
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              memory: 128Mi
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: metrics
+            initialDelaySeconds: 5
+            periodSeconds: 15

--- a/cluster/apps/monitoring/pve-exporter/externalsecret.yaml
+++ b/cluster/apps/monitoring/pve-exporter/externalsecret.yaml
@@ -1,0 +1,29 @@
+---
+# Proxmox read-only API token (PVEAuditor role).
+# 1Password item: "pve-exporter" (homelab vault), fields: user, token_name, token_value.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pve-exporter
+  namespace: monitoring
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: pve-exporter
+    creationPolicy: Owner
+  data:
+    - secretKey: PVE_USER
+      remoteRef:
+        key: "pve-exporter"
+        property: user
+    - secretKey: PVE_TOKEN_NAME
+      remoteRef:
+        key: "pve-exporter"
+        property: token_name
+    - secretKey: PVE_TOKEN_VALUE
+      remoteRef:
+        key: "pve-exporter"
+        property: token_value

--- a/cluster/apps/monitoring/pve-exporter/prometheusrule.yaml
+++ b/cluster/apps/monitoring/pve-exporter/prometheusrule.yaml
@@ -1,0 +1,37 @@
+---
+# Proxmox alerts → Mimir ruler → Alertmanager → Telegram/CasaBot.
+# ProxmoxVMDown is the alert that would have paged on worker-02 stopping.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: proxmox-alerts
+  namespace: monitoring
+  labels:
+    app.kubernetes.io/part-of: monitoring
+spec:
+  groups:
+    - name: proxmox
+      rules:
+        - alert: ProxmoxVMDown
+          expr: pve_up{id=~"qemu/.*"} == 0
+          for: 2m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Proxmox VM {{ $labels.id }} is not running"
+        - alert: ProxmoxNodeDown
+          expr: pve_up{id=~"node/.*"} == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Proxmox node {{ $labels.id }} is down"
+        - alert: ProxmoxStorageAlmostFull
+          expr: |
+            pve_disk_usage_bytes{id=~"storage/.*"}
+              / pve_disk_size_bytes{id=~"storage/.*"} > 0.90
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Proxmox storage {{ $labels.id }} over 90% full"

--- a/cluster/apps/monitoring/pve-exporter/service.yaml
+++ b/cluster/apps/monitoring/pve-exporter/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pve-exporter
+  namespace: monitoring
+  labels:
+    app: pve-exporter
+spec:
+  selector:
+    app: pve-exporter
+  ports:
+    - name: metrics
+      port: 9221
+      targetPort: metrics
+      protocol: TCP

--- a/cluster/apps/monitoring/pve-exporter/servicemonitor.yaml
+++ b/cluster/apps/monitoring/pve-exporter/servicemonitor.yaml
@@ -1,0 +1,23 @@
+---
+# Scrape the exporter's /pve endpoint with target=<a Proxmox cluster member>. The 3
+# hosts form one quorate cluster ("homelab"), so any one target returns cluster-wide
+# metrics for all VMs/nodes. Discovered by Alloy (prometheusOperatorObjects feature).
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: pve-exporter
+  namespace: monitoring
+  labels:
+    app: pve-exporter
+spec:
+  selector:
+    matchLabels:
+      app: pve-exporter
+  endpoints:
+    - port: metrics
+      path: /pve
+      interval: 60s
+      scrapeTimeout: 30s
+      params:
+        target:
+          - "192.168.1.12" # nas — any cluster member yields all VMs

--- a/cluster/argocd/apps/pve-exporter.yaml
+++ b/cluster/argocd/apps/pve-exporter.yaml
@@ -1,0 +1,28 @@
+---
+# Proxmox VE exporter — hypervisor + VM-level metrics (incl. VM power state) via the
+# Proxmox API, so a stopped/crashed VM (like worker-02) is visible in Grafana/alerts.
+# Plain manifests; Alloy discovers its ServiceMonitor. Wave 6 (after CRDs + Alloy).
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: pve-exporter
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "6"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: kuberseni
+  source:
+    repoURL: https://github.com/Arsenikki/kuberseni-gitops
+    targetRevision: main
+    path: cluster/apps/monitoring/pve-exporter
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: monitoring
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
Adds `prometheus-pve-exporter` (3.9.0) — the gap that hid worker-02 stopping (in-cluster monitoring can't see a halted VM).

- Deployment + Service, read-only `PVEAuditor` API token via ESO/1Password (`pve-exporter`), non-root + read-only rootfs.
- ServiceMonitor scrapes `/pve?target=<nas>`; the 3 Proxmox hosts are one quorate cluster (`homelab`) so a single target yields all VM/node/storage metrics. Discovered by Alloy.
- PrometheusRule → Mimir ruler → Telegram: **ProxmoxVMDown** (would've paged on worker-02), ProxmoxNodeDown, ProxmoxStorageAlmostFull.

Covers single-VM/node loss while the cluster is up; full-cluster outage still needs an external watchdog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)