### PR TITLE
fix(argocd): claudtainer repo credential password empty (Helm tpl ate ESO template)

### DIFF
--- a/cluster/bootstrap/argocd/values.yaml
+++ b/cluster/bootstrap/argocd/values.yaml
@@ -152,6 +152,12 @@ extraObjects:
   # 1Password item "claudtainer" (vault homelab) must have a read-only
   # fine-grained PAT for that repo in field `github_pat`.
   # (Skip this block if you make the claudtainer-homelab repo public.)
+  #
+  # NOTE: this object is rendered through the argo-cd chart's `tpl` on
+  # extraObjects, so Helm evaluates any `{{ ... }}` BEFORE ESO does. We must NOT
+  # use an ESO template like `{{ .github_pat }}` here — Helm would consume it and
+  # render an empty password. Instead map `password` directly as a secretKey and
+  # use mergePolicy: Merge so the static type/url/username are merged on top.
   - apiVersion: external-secrets.io/v1
     kind: ExternalSecret
     metadata:
@@ -166,6 +172,7 @@ extraObjects:
         name: claudtainer-homelab-repo
         creationPolicy: Owner
         template:
+          mergePolicy: Merge
           metadata:
             labels:
               argocd.argoproj.io/secret-type: repository
@@ -173,9 +180,8 @@ extraObjects:
             type: git
             url: https://github.com/Arsenikki/claudtainer-homelab
             username: Arsenikki
-            password: "{{ .github_pat }}"
       data:
-        - secretKey: github_pat
+        - secretKey: password
           remoteRef:
             key: "claudtainer"
             property: github_pat


### PR DESCRIPTION
## Root cause
The `claudtainer` ArgoCD Application never deployed — `ComparisonError: authentication required: Repository not found`, no `claudtainer` namespace, no pods.

The repo credential is defined as an **argo-cd chart `extraObject`** (`cluster/bootstrap/argocd/values.yaml`). The chart renders extraObjects through Helm `tpl`, so **Helm evaluated the ESO template `{{ .github_pat }}` itself** — it's not a Helm value, so it rendered to **empty** before External Secrets ever processed it. Result: the ArgoCD repo Secret had `password: ""` → ArgoCD couldn't auth → "repo not found".

Verified live: the applied ExternalSecret's `template.data.password` is empty, while the mimir alertmanager ES (a plain manifest, not Helm-templated) keeps `bot_token: '{{ .token }}'` intact. 1Password/Connect/ESO are all fine — Connect serves `github_pat` (len 93) correctly.

## Fix
No `{{ }}` in the Helm-templated object: map `password` directly as a `secretKey` and use ESO `mergePolicy: Merge` so the static `type`/`url`/`username` merge on top. Nothing for Helm's `tpl` to consume.

After merge: the `argocd` app re-renders the ES → ESO populates `password` → the `claudtainer` app clones and deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository credential configuration in Argo CD bootstrap to improve external secret handling and credential sourcing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->