### PR TITLE
feat(alerting): one message per alert + emoji Telegram template

### DIFF
--- a/cluster/apps/monitoring/alertmanager/deployment.yaml
+++ b/cluster/apps/monitoring/alertmanager/deployment.yaml
@@ -55,6 +55,9 @@ spec:
             - name: config
               mountPath: /etc/alertmanager
               readOnly: true
+            - name: templates
+              mountPath: /etc/alertmanager-templates
+              readOnly: true
             - name: data
               mountPath: /alertmanager
             # readOnlyRootFilesystem leaves no writable temp dir — give AM one.
@@ -82,6 +85,9 @@ spec:
         - name: config
           secret:
             secretName: alertmanager-config
+        - name: templates
+          configMap:
+            name: alertmanager-templates
         - name: data
           persistentVolumeClaim:
             claimName: alertmanager-data

--- a/cluster/apps/monitoring/alertmanager/externalsecret.yaml
+++ b/cluster/apps/monitoring/alertmanager/externalsecret.yaml
@@ -28,9 +28,15 @@ spec:
     template:
       data:
         alertmanager.yml: |
+          # `['...']` = group by ALL labels → effectively NO aggregation, so each
+          # distinct alert is its own Telegram message. Lets you reply to one specific
+          # alert and @mention the agent to investigate just that one. Fine at homelab
+          # alert volume.
+          templates:
+            - /etc/alertmanager-templates/*.tmpl
           route:
             receiver: telegram
-            group_by: ['alertname', 'namespace']
+            group_by: ['...']
             group_wait: 30s
             group_interval: 5m
             repeat_interval: 4h
@@ -43,6 +49,10 @@ spec:
                   message_thread_id: {{ .topic }}
                   parse_mode: HTML
                   send_resolved: true
+                  # Custom emoji template (see alertmanager-templates ConfigMap). The
+                  # braces are escaped so ESO emits them literally for Alertmanager to
+                  # evaluate at notify time, instead of consuming them at render time.
+                  message: '{{ "{{" }} template "telegram.casa.message" . {{ "}}" }}'
   data:
     - secretKey: token
       remoteRef:

--- a/cluster/apps/monitoring/alertmanager/templates-configmap.yaml
+++ b/cluster/apps/monitoring/alertmanager/templates-configmap.yaml
@@ -1,0 +1,27 @@
+---
+# Telegram message template for Alertmanager. Kept in a ConfigMap (NOT the
+# ESO-rendered Secret) on purpose: ESO Go-templates the whole alertmanager.yml, so
+# any `{{ ... }}` Alertmanager-template syntax placed there would be consumed by ESO
+# before Alertmanager sees it. A separate .tmpl file is never ESO-processed, so its
+# braces survive. The Secret only references this template by name (one escaped line).
+#
+# parse_mode is HTML (set in the telegram_config), so <b>/<i>/<code> render. Alert
+# annotation values are assumed plain text (no raw < > &) — true for our PrometheusRules.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager-templates
+  namespace: monitoring
+  labels:
+    app: alertmanager
+data:
+  telegram.tmpl: |
+    {{ define "telegram.casa.message" }}
+    {{- range .Alerts }}
+    {{ if eq .Status "firing" }}{{ if eq .Labels.severity "critical" }}🚨{{ else if eq .Labels.severity "warning" }}⚠️{{ else }}🔔{{ end }}{{ else }}✅ <b>RESOLVED</b> · {{ end }}<b>{{ .Labels.alertname }}</b>{{ with .Labels.severity }} · <i>{{ . }}</i>{{ end }}
+    {{ with .Annotations.summary }}{{ . }}
+    {{ end }}{{- with .Annotations.description }}{{ . }}
+    {{ end }}{{- with .Labels.namespace }}📦 <code>{{ . }}</code>  {{ end }}{{- with .Labels.instance }}🖥 <code>{{ . }}</code>  {{ end }}{{- with .Labels.job }}⚙️ <code>{{ . }}</code>{{ end }}
+    {{ end }}
+    ↩️ <i>reply + mention @CasaAgenticBot to investigate</i>
+    {{- end }}


### PR DESCRIPTION
Follow-up to #410. Two UX fixes for the standalone Alertmanager.

## 1. One message per alert
Was `group_by: ['alertname', 'namespace']` → all 6 `TargetDown` alerts collapsed into a single message. Replying to it would pull the agent into every alert at once.

Now `group_by: ['...']` (Alertmanager's "group by all labels" = no aggregation) → **each distinct alert is its own message**, so you reply to the specific one you want investigated. Fine at homelab alert volume.

## 2. Emoji / HTML template
Default AM message is ugly. Added a custom template: severity icon (🚨/⚠️/🔔, ✅ on resolve), bold alertname, summary/description, `📦 namespace · 🖥 instance · ⚙️ job`, and a `↩️ reply + mention @CasaAgenticBot to investigate` footer.

**Why a ConfigMap, not the ESO Secret:** ESO Go-templates the whole `alertmanager.yml`, so AM-template `{{ }}` placed there gets consumed by ESO before Alertmanager sees it (same class as the Helm-`tpl` gotcha). The template lives in a plain `.tmpl` ConfigMap (never ESO-processed); the Secret references it via a single ESO-escaped `message:` line (`{{ "{{" }} … {{ "}}" }}`).

## Validation
`amtool check-config` (v0.28.1) against an ESO-rendered copy → **SUCCESS** (config + template parse, 1 template loaded). No crashloop risk.

After merge: ESO re-renders → Reloader restarts the AM → new grouping + template live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)