### PR TITLE
fix(alerting): route alerts to the Alerts topic, not debug

### DIFF
--- a/cluster/apps/monitoring/alertmanager/externalsecret.yaml
+++ b/cluster/apps/monitoring/alertmanager/externalsecret.yaml
@@ -9,9 +9,10 @@
 # and topic id come from 1Password so they never land in this PUBLIC repo.
 #
 # 1Password item "CasaBot (Telegram)" properties:
-#   credential     — alert bot token (@CasaAlertingBot — separate from the agent bot)
-#   chat_id        — Casa Automation supergroup id (-100…)
-#   topic_debug_id — forum Topic (message_thread_id) alerts post into
+#   credential      — alert bot token (@CasaAlertingBot — separate from the agent bot)
+#   chat_id         — Casa Automation supergroup id (-100…)
+#   topic_alerts_id — forum Topic (message_thread_id) alerts post into (the "Alerts"
+#                     topic; topic_debug_id is a different topic, kept for other use)
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -65,4 +66,4 @@ spec:
     - secretKey: topic
       remoteRef:
         key: "CasaBot (Telegram)"
-        property: topic_debug_id
+        property: topic_alerts_id


### PR DESCRIPTION
Alerts were landing in the **debug** topic because the telegram `message_thread_id` was sourced from `topic_debug_id` (=3) — the only topic id we had at setup.

Repoint the `topic` secretKey to **`topic_alerts_id`** (=8, the "Alerts" topic; added to 1Password `CasaBot (Telegram)`). `topic_debug_id` stays for other uses.

After merge: ESO re-renders → Reloader restarts the AM → next alerts post into **Alerts**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)