### PR TITLE
feat(media): media-notifier — pretty Telegram notifications relay

### DIFF
--- a/cluster/apps/media/media-notifier/configmap.yaml
+++ b/cluster/apps/media/media-notifier/configmap.yaml
@@ -1,0 +1,154 @@
+---
+# media-notifier relay script. Receives Sonarr/Radarr/Overseerr webhooks and posts
+# pretty Telegram messages. Stdlib only (http.server + urllib) → runs on a stock
+# python:alpine image with ZERO pip deps; no custom image to build/maintain.
+# Mounted read-only at /app; Reloader restarts the pod when this ConfigMap changes.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: media-notifier
+  namespace: media
+  labels:
+    app: media-notifier
+data:
+  relay.py: |
+    #!/usr/bin/env python3
+    """media-notifier — Sonarr/Radarr/Overseerr webhooks -> pretty Telegram messages.
+    Stdlib only. Env: TG_BOT_TOKEN, TG_CHAT_ID, TG_TOPIC_ID (empty = General topic)."""
+    import json, os, html, urllib.request, urllib.parse
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    TOKEN = os.environ.get("TG_BOT_TOKEN", "")
+    CHAT  = os.environ.get("TG_CHAT_ID", "")
+    TOPIC = os.environ.get("TG_TOPIC_ID", "").strip()
+
+    def esc(s):
+        return html.escape(str(s)) if s is not None else ""
+
+    def tg_send(text):
+        if not (TOKEN and CHAT):
+            print("[notifier] missing TG_BOT_TOKEN/TG_CHAT_ID", flush=True); return
+        params = {"chat_id": CHAT, "text": text, "parse_mode": "HTML",
+                  "disable_web_page_preview": "true"}
+        if TOPIC:
+            params["message_thread_id"] = TOPIC
+        req = urllib.request.Request(
+            "https://api.telegram.org/bot%s/sendMessage" % TOKEN,
+            data=urllib.parse.urlencode(params).encode())
+        try:
+            urllib.request.urlopen(req, timeout=15)
+        except Exception as e:
+            body = e.read().decode()[:300] if hasattr(e, "read") else ""
+            print("[notifier] telegram send failed: %s %s" % (e, body), flush=True)
+
+    def _quality(d, key):
+        q = d.get(key) or {}
+        if isinstance(q, dict) and q.get("quality"):
+            return q["quality"]
+        return (d.get("release") or {}).get("quality") or ""
+
+    def fmt_sonarr(d):
+        et = d.get("eventType")
+        if et == "Test":
+            return "✅ <b>Sonarr</b> connected to media-notifier."
+        if et not in ("Grab", "Download"):
+            return None
+        series = (d.get("series") or {}).get("title", "?")
+        eps = d.get("episodes") or []
+        code = eptitle = ""
+        if eps:
+            e0 = eps[0]
+            code = "S%02dE%02d" % (e0.get("seasonNumber", 0), e0.get("episodeNumber", 0))
+            if len(eps) > 1:
+                code += " (+%d)" % (len(eps) - 1)
+            eptitle = e0.get("title", "")
+        qual = _quality(d, "episodeFile")
+        if et == "Grab":
+            head = "\U0001F4E5 <b>Grabbed</b>"
+        else:
+            head = "⬆️ <b>Upgraded</b>" if d.get("isUpgrade") else "\U0001F4FA <b>Downloaded</b>"
+        msg = "%s — <b>%s</b> %s" % (head, esc(series), esc(code))
+        if eptitle:
+            msg += "\n<i>%s</i>" % esc(eptitle)
+        if qual:
+            msg += "\n\U0001F39E %s" % esc(qual)
+        return msg
+
+    def fmt_radarr(d):
+        et = d.get("eventType")
+        if et == "Test":
+            return "✅ <b>Radarr</b> connected to media-notifier."
+        if et not in ("Grab", "Download"):
+            return None
+        movie = d.get("movie") or {}
+        title, year = movie.get("title", "?"), movie.get("year", "")
+        qual = _quality(d, "movieFile")
+        if et == "Grab":
+            head = "\U0001F4E5 <b>Grabbed</b>"
+        else:
+            head = "⬆️ <b>Upgraded</b>" if d.get("isUpgrade") else "\U0001F3AC <b>Downloaded</b>"
+        msg = "%s — <b>%s</b>%s" % (head, esc(title), (" (%s)" % esc(year) if year else ""))
+        if qual:
+            msg += "\n\U0001F39E %s" % esc(qual)
+        return msg
+
+    def fmt_overseerr(d):
+        nt = d.get("notification_type", "")
+        if nt == "TEST_NOTIFICATION":
+            return "✅ <b>Overseerr</b> connected to media-notifier."
+        icons = {"MEDIA_PENDING": "\U0001F195 <b>Requested</b>",
+                 "MEDIA_APPROVED": "✅ <b>Approved</b>",
+                 "MEDIA_AUTO_APPROVED": "✅ <b>Auto-approved</b>",
+                 "MEDIA_AVAILABLE": "\U0001F389 <b>Available</b>",
+                 "MEDIA_DECLINED": "\U0001F6AB <b>Declined</b>",
+                 "MEDIA_FAILED": "⚠️ <b>Failed</b>"}
+        head = icons.get(nt, "ℹ️ <b>%s</b>" % esc(nt))
+        msg = "%s — <b>%s</b>" % (head, esc(d.get("subject", "")))
+        bits = []
+        mtype = (d.get("media") or {}).get("media_type", "")
+        requester = (d.get("request") or {}).get("requestedBy_username", "")
+        if mtype:
+            bits.append(esc(mtype))
+        if requester:
+            bits.append("by %s" % esc(requester))
+        if bits:
+            msg += "\n" + " · ".join(bits)
+        return msg
+
+    ROUTES = {"/sonarr": fmt_sonarr, "/radarr": fmt_radarr, "/overseerr": fmt_overseerr}
+
+    class H(BaseHTTPRequestHandler):
+        def log_message(self, *a):
+            pass
+
+        def do_GET(self):
+            if self.path in ("/healthz", "/"):
+                self.send_response(200); self.end_headers(); self.wfile.write(b"ok")
+            else:
+                self.send_response(404); self.end_headers()
+
+        def do_POST(self):
+            fmt = ROUTES.get(self.path.rstrip("/"))
+            if not fmt:
+                self.send_response(404); self.end_headers(); return
+            try:
+                n = int(self.headers.get("Content-Length", 0))
+                payload = json.loads(self.rfile.read(n) or b"{}")
+            except Exception as e:
+                print("[notifier] bad payload: %s" % e, flush=True)
+                self.send_response(400); self.end_headers(); return
+            try:
+                msg = fmt(payload)
+                tag = payload.get("eventType") or payload.get("notification_type")
+                if msg:
+                    tg_send(msg)
+                    print("[notifier] %s %s -> sent" % (self.path, tag), flush=True)
+                else:
+                    print("[notifier] %s %s -> ignored" % (self.path, tag), flush=True)
+            except Exception as e:
+                print("[notifier] handler error: %s" % e, flush=True)
+            self.send_response(200); self.end_headers(); self.wfile.write(b"ok")
+
+    if __name__ == "__main__":
+        print("[notifier] listening :8080 (chat=%s topic=%s)" % (CHAT, TOPIC or "General"), flush=True)
+        ThreadingHTTPServer(("0.0.0.0", 8080), H).serve_forever()

--- a/cluster/apps/media/media-notifier/configmap.yaml
+++ b/cluster/apps/media/media-notifier/configmap.yaml
@@ -15,19 +15,39 @@ data:
     #!/usr/bin/env python3
     """media-notifier — Sonarr/Radarr/Overseerr webhooks -> pretty Telegram messages.
     Stdlib only. Env: TG_BOT_TOKEN, TG_CHAT_ID, TG_TOPIC_ID (empty = General topic)."""
-    import json, os, html, urllib.request, urllib.parse
+    import base64, hmac, json, os, html, urllib.request, urllib.parse
     from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
     TOKEN = os.environ.get("TG_BOT_TOKEN", "")
     CHAT  = os.environ.get("TG_CHAT_ID", "")
     TOPIC = os.environ.get("TG_TOPIC_ID", "").strip()
+    # Shared secret. If set, callers must present it (Bearer or Basic password) — stops
+    # any in-cluster workload from forging notifications. Empty = auth disabled.
+    WEBHOOK_TOKEN = os.environ.get("WEBHOOK_TOKEN", "").strip()
+    MAX_BODY = 256 * 1024  # cap request body to avoid memory/thread exhaustion
 
     def esc(s):
         return html.escape(str(s)) if s is not None else ""
 
+    def authorized(headers):
+        if not WEBHOOK_TOKEN:
+            return True
+        h = headers.get("Authorization", "")
+        if h.startswith("Bearer "):
+            return hmac.compare_digest(h[7:].strip(), WEBHOOK_TOKEN)
+        if h.startswith("Basic "):
+            try:
+                raw = base64.b64decode(h[6:].strip()).decode()
+                pw = raw.split(":", 1)[1] if ":" in raw else raw
+            except Exception:
+                return False
+            return hmac.compare_digest(pw, WEBHOOK_TOKEN)
+        return False
+
     def tg_send(text):
+        """Raises on failure so the caller can return a non-2xx (never silently drop)."""
         if not (TOKEN and CHAT):
-            print("[notifier] missing TG_BOT_TOKEN/TG_CHAT_ID", flush=True); return
+            raise RuntimeError("missing TG_BOT_TOKEN/TG_CHAT_ID")
         params = {"chat_id": CHAT, "text": text, "parse_mode": "HTML",
                   "disable_web_page_preview": "true"}
         if TOPIC:
@@ -35,11 +55,7 @@ data:
         req = urllib.request.Request(
             "https://api.telegram.org/bot%s/sendMessage" % TOKEN,
             data=urllib.parse.urlencode(params).encode())
-        try:
-            urllib.request.urlopen(req, timeout=15)
-        except Exception as e:
-            body = e.read().decode()[:300] if hasattr(e, "read") else ""
-            print("[notifier] telegram send failed: %s %s" % (e, body), flush=True)
+        urllib.request.urlopen(req, timeout=15)
 
     def _quality(d, key):
         q = d.get(key) or {}
@@ -127,27 +143,46 @@ data:
             else:
                 self.send_response(404); self.end_headers()
 
+        def _reply(self, code, body=b""):
+            self.send_response(code); self.end_headers()
+            if body:
+                self.wfile.write(body)
+
         def do_POST(self):
             fmt = ROUTES.get(self.path.rstrip("/"))
             if not fmt:
-                self.send_response(404); self.end_headers(); return
+                return self._reply(404)
+            if not authorized(self.headers):
+                print("[notifier] %s unauthorized" % self.path, flush=True)
+                return self._reply(401)
             try:
                 n = int(self.headers.get("Content-Length", 0))
+            except (TypeError, ValueError):
+                return self._reply(411)
+            if n <= 0 or n > MAX_BODY:
+                return self._reply(413)
+            try:
                 payload = json.loads(self.rfile.read(n) or b"{}")
             except Exception as e:
                 print("[notifier] bad payload: %s" % e, flush=True)
-                self.send_response(400); self.end_headers(); return
+                return self._reply(400)
+            tag = payload.get("eventType") or payload.get("notification_type")
             try:
                 msg = fmt(payload)
-                tag = payload.get("eventType") or payload.get("notification_type")
-                if msg:
-                    tg_send(msg)
-                    print("[notifier] %s %s -> sent" % (self.path, tag), flush=True)
-                else:
-                    print("[notifier] %s %s -> ignored" % (self.path, tag), flush=True)
-            except Exception as e:
-                print("[notifier] handler error: %s" % e, flush=True)
-            self.send_response(200); self.end_headers(); self.wfile.write(b"ok")
+            except Exception as e:                       # formatter bug — surface it
+                print("[notifier] %s formatter error: %s" % (self.path, e), flush=True)
+                return self._reply(500)
+            if not msg:                                  # event we deliberately ignore
+                print("[notifier] %s %s -> ignored" % (self.path, tag), flush=True)
+                return self._reply(200, b"ignored")
+            try:
+                tg_send(msg)
+            except Exception as e:                       # don't ACK a failed delivery
+                body = e.read().decode()[:300] if hasattr(e, "read") else ""
+                print("[notifier] %s telegram send failed: %s %s" % (self.path, e, body), flush=True)
+                return self._reply(502)
+            print("[notifier] %s %s -> sent" % (self.path, tag), flush=True)
+            self._reply(200, b"ok")
 
     if __name__ == "__main__":
         print("[notifier] listening :8080 (chat=%s topic=%s)" % (CHAT, TOPIC or "General"), flush=True)

--- a/cluster/apps/media/media-notifier/deployment.yaml
+++ b/cluster/apps/media/media-notifier/deployment.yaml
@@ -1,0 +1,83 @@
+---
+# Single relay pod for all media notifications. Off-the-shelf python:alpine running
+# the stdlib-only script from the media-notifier ConfigMap — no custom image, minimal
+# deps. Reloader restarts it when the ConfigMap or secret changes.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: media-notifier
+  namespace: media
+  labels:
+    app: media-notifier
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: media-notifier
+  template:
+    metadata:
+      labels:
+        app: media-notifier
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: media-notifier
+          image: python:3.12-alpine
+          command: ["python3", "/app/relay.py"]
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            # Empty => post to the group's General topic. Set to a thread id later
+            # to route media notifications into a dedicated Topic.
+            - name: TG_TOPIC_ID
+              value: ""
+          envFrom:
+            - secretRef:
+                name: media-notifier-telegram   # TG_BOT_TOKEN, TG_CHAT_ID
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: app
+              mountPath: /app
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 64Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+      volumes:
+        - name: app
+          configMap:
+            name: media-notifier
+        - name: tmp
+          emptyDir: {}

--- a/cluster/apps/media/media-notifier/deployment.yaml
+++ b/cluster/apps/media/media-notifier/deployment.yaml
@@ -21,6 +21,8 @@ spec:
       labels:
         app: media-notifier
     spec:
+      # Relay never calls the Kubernetes API — don't mount a SA token.
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534

--- a/cluster/apps/media/media-notifier/externalsecret.yaml
+++ b/cluster/apps/media/media-notifier/externalsecret.yaml
@@ -1,0 +1,25 @@
+---
+# Telegram creds for media-notifier (posts via @CasaAlertingBot).
+# 1Password item "CasaBot (Telegram)" (vault homelab): credential (bot token), chat_id.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: media-notifier-telegram
+  namespace: media
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: media-notifier-telegram
+    creationPolicy: Owner
+  data:
+    - secretKey: TG_BOT_TOKEN
+      remoteRef:
+        key: "CasaBot (Telegram)"
+        property: credential
+    - secretKey: TG_CHAT_ID
+      remoteRef:
+        key: "CasaBot (Telegram)"
+        property: chat_id

--- a/cluster/apps/media/media-notifier/externalsecret.yaml
+++ b/cluster/apps/media/media-notifier/externalsecret.yaml
@@ -1,6 +1,7 @@
 ---
-# Telegram creds for media-notifier (posts via @CasaAlertingBot).
-# 1Password item "CasaBot (Telegram)" (vault homelab): credential (bot token), chat_id.
+# Telegram creds + webhook shared secret for media-notifier (posts via @CasaAlertingBot).
+# 1Password item "CasaBot (Telegram)" (vault homelab): credential (bot token), chat_id,
+# webhook_token (shared secret callers must present as Bearer/Basic password).
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -23,3 +24,7 @@ spec:
       remoteRef:
         key: "CasaBot (Telegram)"
         property: chat_id
+    - secretKey: WEBHOOK_TOKEN
+      remoteRef:
+        key: "CasaBot (Telegram)"
+        property: webhook_token

--- a/cluster/apps/media/media-notifier/service.yaml
+++ b/cluster/apps/media/media-notifier/service.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: media-notifier
+  namespace: media
+  labels:
+    app: media-notifier
+spec:
+  selector:
+    app: media-notifier
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP

--- a/cluster/argocd/apps/media-notifier.yaml
+++ b/cluster/argocd/apps/media-notifier.yaml
@@ -1,0 +1,30 @@
+---
+# media-notifier — single relay pod that turns Sonarr/Radarr/Overseerr webhooks into
+# pretty Telegram messages. Plain manifests (ConfigMap script + Deployment + Service +
+# ESO secret); stdlib-only on a stock python:alpine image. Wave 5.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: media-notifier
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: kuberseni
+  source:
+    repoURL: https://github.com/Arsenikki/kuberseni-gitops
+    targetRevision: main
+    path: cluster/apps/media/media-notifier
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: media
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
A single relay pod that turns **Sonarr/Radarr/Overseerr webhooks → pretty Telegram messages** (emoji + HTML), posting via @CasaAlertingBot to the group's **General** topic.

## Why a relay (and why one pod, not sidecars)
Sonarr/Radarr's built-in Telegram Connect has **no message template** — fixed format, no emoji. Custom formatting needs a webhook relay. Chose **one shared pod** over per-app sidecars: webhooks are app-agnostic HTTP, so a single stateless relay covers all *arr + future apps with one secret/config, decoupled from each app's lifecycle (Sonarr restart won't bounce it; adding qBittorrent/Tautulli later = just point another webhook at the same Service).

## Minimal by design
- stock **`python:3.12-alpine`** + a **stdlib-only** script (`http.server` + `urllib`, **zero pip deps**) mounted from a **ConfigMap** — no custom image to build/maintain
- restricted PodSecurity (nonroot 65534, drop ALL, RO rootfs, seccomp), Reloader-annotated (ConfigMap/secret change → restart)

## Contents
| file | purpose |
|---|---|
| `configmap.yaml` | `relay.py` — routes `/sonarr /radarr /overseerr`; formats by `eventType` (Test/Grab/Download/Upgrade for *arr; request lifecycle for Overseerr) |
| `deployment.yaml` | python:alpine running the script, `envFrom` ESO secret |
| `service.yaml` | `:8080` |
| `externalsecret.yaml` | `TG_BOT_TOKEN`/`TG_CHAT_ID` from 1Password `CasaBot (Telegram)` |
| `cluster/argocd/apps/media-notifier.yaml` | ArgoCD app (wave 5) |

Sample output: `📺 *Downloaded* — Severance S02E03 / Who Is Alive? / 🎞 WEBDL-1080p`, `🎬 *Downloaded* — Dune Part Two (2024) / 🎞 Bluray-2160p`.

`TG_TOPIC_ID` empty ⇒ General; set later to route into a dedicated Media topic.

## After merge
Point Sonarr + Radarr **Webhook Connect** at `http://media-notifier.media.svc.cluster.local:8080/{sonarr,radarr}` (I'll switch them via the API, replacing the current built-in Telegram Connect). Overseerr handler is ready for when you wire requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Media Notifier service that forwards webhook notifications from Sonarr, Radarr, and Overseerr to Telegram
  * Automatically formats and sends notifications for media grab/download events and user requests with status indicators
  * Includes health monitoring endpoints for service status verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->