### PR TITLE
feat(monitoring): fix Grafana sync + add k8s community dashboards

### DIFF
--- a/cluster/apps/monitoring/grafana/values.yaml
+++ b/cluster/apps/monitoring/grafana/values.yaml
@@ -79,8 +79,47 @@ datasources:
         secureJsonData:
           httpHeaderValue1: "homelab"
 
-# Dashboards-as-code: the sidecar loads any ConfigMap labeled grafana_dashboard
-# (see observability/ for the imported community dashboards).
+# Community dashboards downloaded from grafana.com at pod startup via init container.
+# Each folder key maps to /var/lib/grafana/dashboards/{folder}/ and needs a matching
+# dashboardProviders entry below.
+dashboardProviders:
+  dashboardproviders.yaml:
+    apiVersion: 1
+    providers:
+      - name: kubernetes
+        orgId: 1
+        folder: Kubernetes
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/kubernetes
+
+dashboards:
+  kubernetes:
+    node-exporter-full:
+      gnetId: 1860
+      revision: 37
+      datasource: Mimir
+    kubernetes-global:
+      gnetId: 15757
+      revision: 37
+      datasource: Mimir
+    kubernetes-namespaces:
+      gnetId: 15758
+      revision: 34
+      datasource: Mimir
+    kubernetes-nodes:
+      gnetId: 15759
+      revision: 29
+      datasource: Mimir
+    kubernetes-pods:
+      gnetId: 15760
+      revision: 29
+      datasource: Mimir
+
+# Dashboards-as-code: the sidecar loads any ConfigMap labeled grafana_dashboard.
+# Coexists with the gnetId download mechanism above.
 sidecar:
   dashboards:
     enabled: true


### PR DESCRIPTION
## Summary

- **Fix Grafana OutOfSync**: live Deployment had `RollingUpdate` strategy; values set `Recreate`. Kubernetes rejected the strategic-merge patch because `rollingUpdate` fields remained. Patched live Deployment directly (`kubectl patch --type=json`) to purge `rollingUpdate`, allowing ArgoCD to sync cleanly. Values were already correct — no code change needed for the fix.
- **Add Kubernetes dashboards**: 5 community dashboards via Grafana chart's `gnetId` init-container download mechanism. Added `dashboardProviders` for the `kubernetes` folder + `dashboards` entries for node-exporter-full and kubernetes-views (global/namespaces/nodes/pods). Init container downloads JSON from grafana.com at pod startup and places in `/var/lib/grafana/dashboards/kubernetes/`.

## Dashboards added

| Name | ID | Folder |
|---|---|---|
| Node Exporter Full | 1860 r37 | Kubernetes |
| Kubernetes / Global | 15757 r37 | Kubernetes |
| Kubernetes / Namespaces | 15758 r34 | Kubernetes |
| Kubernetes / Nodes | 15759 r29 | Kubernetes |
| Kubernetes / Pods | 15760 r29 | Kubernetes |

## Test plan

- [ ] ArgoCD grafana app goes Synced (was retrying 5x)
- [ ] Grafana pod restarts with `Recreate` strategy on next rollout
- [ ] `Kubernetes` folder visible in Grafana with 5 dashboards
- [ ] Node Exporter Full shows node metrics from Mimir

🤖 Generated with [Claude Code](https://claude.com/claude-code)