### PR TITLE
fix(monitoring): pin Grafana to worker-01 — worker-02 layer corruption

### DIFF
--- a/cluster/apps/monitoring/grafana/values.yaml
+++ b/cluster/apps/monitoring/grafana/values.yaml
@@ -1,6 +1,19 @@
 ---
 # Grafana — Mimir + Loki datasources, Authentik OIDC SSO, dashboards-as-code.
 
+# worker-02 (Celeron N5105, NAS host) has a corrupted containerd layer for this image
+# (bash binary is 0 bytes, causing exec /run.sh: exec format error). worker-01 (i5-13500H)
+# is also the better host: 10 CPU / 20 GB vs 3 CPU / 16 GB.
+affinity:
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: kubernetes.io/hostname
+              operator: In
+              values:
+                - worker-01
+
 persistence:
   enabled: true
   size: 2Gi


### PR DESCRIPTION
worker-02 (Celeron N5105, NAS host) has a corrupted containerd layer for `grafana:12.3.1`. The bash binary in the image is stored as 0 bytes on that node, causing `exec /run.sh: exec format error` at startup. Same image digest shows correct bash (789KB) on worker-01 — reproducible but not fixable without CRI restart (which would disrupt loki/seaweedfs StatefulSets on worker-02).

Pinning to worker-01 via `nodeAffinity` is the right long-term call anyway: i5-13500H with 10 CPU / 20 GB vs Celeron N5105 with 3 CPU / 16 GB.

## Root cause investigation

- `exec /run.sh: exec format error` on worker-02, fine on worker-01
- Same image digest (`sha256:2175aaa...`) on both nodes
- `kubectl exec` into test pod on worker-02: `/bin/bash` = 0 bytes
- `kubectl exec` into running Grafana on worker-01: `/bin/bash` = 789KB
- Conclusion: containerd overlay/content store corruption on worker-02 for this specific layer

## Test plan

- [ ] ArgoCD syncs grafana cleanly
- [ ] Grafana pod scheduled on worker-01 and stays 2/2 Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)