### PR TITLE
fix(alerts): ProxmoxVMDown opt-in via `critical` tag

### DIFF
--- a/cluster/apps/monitoring/pve-exporter/prometheusrule.yaml
+++ b/cluster/apps/monitoring/pve-exporter/prometheusrule.yaml
@@ -13,7 +13,14 @@ spec:
     - name: proxmox
       rules:
         - alert: ProxmoxVMDown
-          expr: pve_up{id=~"qemu/.*"} == 0
+          # Only VMs that are SUPPOSED to run. Tag intentionally-off VMs in Proxmox
+          # with `noalert` (`qm set <vmid> --tags noalert`) to suppress them. Templates
+          # never run, so exclude them too. If a label isn't populated the `unless`
+          # matches nothing and the alert behaves as before (no accidental silencing).
+          expr: |
+            pve_up{id=~"qemu/.*"} == 0
+              unless on(id) pve_guest_info{template="1"}
+              unless on(id) pve_guest_info{tags=~".*noalert.*"}
           for: 2m
           labels:
             severity: warning

--- a/cluster/apps/monitoring/pve-exporter/prometheusrule.yaml
+++ b/cluster/apps/monitoring/pve-exporter/prometheusrule.yaml
@@ -17,9 +17,12 @@ spec:
           # (`qm set <vmid> --tags critical`). Everything else — intentionally-off VMs,
           # templates, throwaway guests — stays quiet by default, so nothing pages
           # unless you've marked it important.
+          # `\bcritical\b` = whole-tag match (separator-agnostic): matches `critical`
+          # alone or among other tags, but NOT substrings like `noncritical`. The
+          # doubled backslash survives YAML; PromQL unescapes it to a regex word boundary.
           expr: |
             pve_up{id=~"qemu/.*"} == 0
-              and on(id) pve_guest_info{tags=~".*critical.*"}
+              and on(id) pve_guest_info{tags=~".*\\bcritical\\b.*"}
           for: 2m
           labels:
             severity: warning

--- a/cluster/apps/monitoring/pve-exporter/prometheusrule.yaml
+++ b/cluster/apps/monitoring/pve-exporter/prometheusrule.yaml
@@ -13,14 +13,13 @@ spec:
     - name: proxmox
       rules:
         - alert: ProxmoxVMDown
-          # Only VMs that are SUPPOSED to run. Tag intentionally-off VMs in Proxmox
-          # with `noalert` (`qm set <vmid> --tags noalert`) to suppress them. Templates
-          # never run, so exclude them too. If a label isn't populated the `unless`
-          # matches nothing and the alert behaves as before (no accidental silencing).
+          # Opt-in allowlist: alert ONLY on VMs explicitly tagged `critical` in Proxmox
+          # (`qm set <vmid> --tags critical`). Everything else — intentionally-off VMs,
+          # templates, throwaway guests — stays quiet by default, so nothing pages
+          # unless you've marked it important.
           expr: |
             pve_up{id=~"qemu/.*"} == 0
-              unless on(id) pve_guest_info{template="1"}
-              unless on(id) pve_guest_info{tags=~".*noalert.*"}
+              and on(id) pve_guest_info{tags=~".*critical.*"}
           for: 2m
           labels:
             severity: warning


### PR DESCRIPTION
`ProxmoxVMDown` fired for **every** stopped qemu guest — including intentionally-off VMs and templates. Noisy.

## Change — allowlist (opt-in)
Alert **only** on VMs explicitly tagged `critical` in Proxmox. Everything else stays quiet by default.
```promql
pve_up{id=~"qemu/.*"} == 0
  and on(id) pve_guest_info{tags=~".*critical.*"}
```
Chosen over the denylist (`noalert`) approach: default-quiet is safer — a new/throwaway/off VM never pages unless you've explicitly marked it important. Uses the `tags` label on `pve_guest_info` (pve-exporter 3.9.0).

## After merge / your part
1. Merge → ArgoCD → Alloy re-syncs the rule to the Mimir ruler.
2. Tag your important VMs: `qm set <vmid> --tags critical` (or Proxmox UI → VM → Options → Tags). Use the exact tag `critical`.
3. Only those page when down; everything else is silent.

Note: kube API was unreachable (control-plane VIP `.40:6443`, likely VIP flapping) when authoring — couldn't confirm the `tags` label is populated live. I'll verify once it's reachable. If `tags` turns out unpopulated, the `and on(id)` yields nothing → no alerts fire (fails quiet, not noisy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)