### PR TITLE
feat(infra): tag Talos nodes + TrueNAS `critical` for VM-down alerts

### DIFF
--- a/infra/terraform/truenas-scale.tf
+++ b/infra/terraform/truenas-scale.tf
@@ -42,6 +42,7 @@ resource "proxmox_virtual_environment_vm" "truenas_scale" {
   bios            = "seabios"
   machine         = "q35"  # PCIe bus required for HDD passthrough; SeaBIOS avoids OVMF/passthrough boot issues
   scsi_hardware   = "virtio-scsi-single"  # One I/O thread per disk via iothread=true
+  tags            = ["critical"]          # ProxmoxVMDown alerts only on `critical`-tagged VMs
 
   agent {
     enabled = true

--- a/infra/terraform/vms.tf
+++ b/infra/terraform/vms.tf
@@ -79,6 +79,7 @@ resource "proxmox_virtual_environment_vm" "controlplane" {
   bios            = "ovmf"  # UEFI — required per Talos Proxmox guide
   machine         = each.value.machine_type != "" ? each.value.machine_type : null
   scsi_hardware   = "virtio-scsi-single"  # required for iothread per disk
+  tags            = ["critical"]          # ProxmoxVMDown alerts only on `critical`-tagged VMs
 
   agent {
     enabled = true
@@ -148,6 +149,7 @@ resource "proxmox_virtual_environment_vm" "worker" {
   bios            = "ovmf"
   machine         = each.value.machine_type != "" ? each.value.machine_type : null
   scsi_hardware   = "virtio-scsi-single"
+  tags            = ["critical"]  # ProxmoxVMDown alerts only on `critical`-tagged VMs
 
   agent {
     enabled = true


### PR DESCRIPTION
Pairs with the `ProxmoxVMDown` opt-in change (#419): that alert now only fires for VMs tagged `critical`. This tags the always-on infra VMs so they actually page when down.

## Tagged (`tags = ["critical"]`)
- **controlplane** — control-plane-01/02/03 (all via `for_each`)
- **worker** — worker-01/02
- **truenas_scale** — TrueNAS-Scale

## OPNsense — not here
`opnsense.tf` is the `browningluke/opnsense` provider (DHCP/network config), **not** a `proxmox_virtual_environment_vm`. OPNsense runs on the `router` node but isn't Terraform-managed, so tag it out-of-band:
```
qm set <opnsense-vmid> --tags critical
```

## Apply
`tofu plan` / `tofu apply` is your step — Proxmox API isn't reachable from where this was authored (cluster VIP currently down). Pure metadata (Proxmox tags); no VM restart. Order vs #419 doesn't matter — alerts fire only once both rule and tags are live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)