### PR TITLE
fix(cert-manager): use personal email for Let's Encrypt account

### DIFF
--- a/cluster/apps/cert-manager/resources/letsencrypt-prod.yaml
+++ b/cluster/apps/cert-manager/resources/letsencrypt-prod.yaml
@@ -6,13 +6,13 @@ metadata:
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory
-    email: "arseni@automata.tech"
+    email: "arsenileskinen@hotmail.com"
     privateKeySecretRef:
       name: letsencrypt-prod
     solvers:
       - dns01:
           cloudflare:
-            email: "arseni@automata.tech"
+            email: "arsenileskinen@hotmail.com"
             apiTokenSecretRef:
               name: cloudflare-token-secret
               key: cloudflare-token

--- a/cluster/apps/cert-manager/resources/letsencrypt-stag.yaml
+++ b/cluster/apps/cert-manager/resources/letsencrypt-stag.yaml
@@ -6,13 +6,13 @@ metadata:
 spec:
   acme:
     server: https://acme-staging-v02.api.letsencrypt.org/directory
-    email: "arseni@automata.tech"
+    email: "arsenileskinen@hotmail.com"
     privateKeySecretRef:
       name: letsencrypt-stag
     solvers:
       - dns01:
           cloudflare:
-            email: "arseni@automata.tech"
+            email: "arsenileskinen@hotmail.com"
             apiTokenSecretRef:
               name: cloudflare-token-secret
               key: cloudflare-token


### PR DESCRIPTION
Switch the ACME account + Cloudflare dns01 solver email on both ClusterIssuers (letsencrypt-prod, letsencrypt-stag) from the work address to a personal one — so Let's Encrypt expiry/account notices reach the homelab owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the contact email used for certificate issuance in both production and staging environments.
  * Aligned the Cloudflare DNS challenge email with the new address for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->