### PR TITLE
chore(monitoring): remove Watchdog always-firing alert

### DIFF
--- a/cluster/apps/monitoring/observability/prometheusrules.yaml
+++ b/cluster/apps/monitoring/observability/prometheusrules.yaml
@@ -12,16 +12,6 @@ metadata:
     app.kubernetes.io/part-of: monitoring
 spec:
   groups:
-    - name: watchdog
-      rules:
-        # Always-firing alert to prove the rule→ruler→Alertmanager→Telegram path works.
-        - alert: Watchdog
-          expr: vector(1)
-          labels:
-            severity: none
-          annotations:
-            summary: "Alerting pipeline is alive"
-
     - name: nodes
       rules:
         - alert: KubeNodeNotReady


### PR DESCRIPTION
Removes the `Watchdog` always-firing alert (`vector(1)`) from the PrometheusRule. It was added during initial setup to verify the rule→Alertmanager→Telegram pipeline, but now just generates spam every 4 hours.