### PR TITLE
feat(grafana): add Proxmox host dashboard and proxmox folder provider

### DIFF
--- a/cluster/apps/monitoring/grafana/values.yaml
+++ b/cluster/apps/monitoring/grafana/values.yaml
@@ -107,6 +107,14 @@ dashboardProviders:
         editable: true
         options:
           path: /var/lib/grafana/dashboards/kubernetes
+      - name: proxmox
+        orgId: 1
+        folder: Proxmox
+        type: file
+        disableDeletion: false
+        editable: true
+        options:
+          path: /var/lib/grafana/dashboards/proxmox
 
 dashboards:
   kubernetes:
@@ -129,6 +137,13 @@ dashboards:
     kubernetes-pods:
       gnetId: 15760
       revision: 29
+      datasource: Mimir
+  proxmox:
+    # pve-exporter scrapes Proxmox API → exposes host (node/*) AND VM (qemu/*) metrics.
+    # Filters id=~"node/.*" show physical host CPU/mem/disk (router/minipc/nas),
+    # not just the k8s VM nodes that node-exporter already covers.
+    pve-overview:
+      gnetId: 10347
       datasource: Mimir
 
 # Dashboards-as-code: the sidecar loads any ConfigMap labeled grafana_dashboard.


### PR DESCRIPTION
## Summary

- Adds a `Proxmox` folder provider to Grafana dashboard provisioning
- Adds gnetId 10347 ("Proxmox VE via Prometheus") dashboard to that folder

## Why

pve-exporter was already deployed and scraping all 3 Proxmox hosts via the cluster API (target=192.168.1.12), but no Grafana dashboard was wired up to show the data.

The distinction matters: node-exporter only sees the k8s VM nodes (worker-01, cp-01, worker-02). pve-exporter exposes `id=~"node/.*"` metrics for the **bare-metal Proxmox hosts** (router/minipc/nas) — actual physical CPU/mem/disk utilization independent of what the VMs report.

Dashboard 10347 shows both host-level and VM-level resource usage in one view, making it easy to see if a physical host is under pressure even if the k8s node appears healthy.

## Existing k8s dashboards (unchanged, listed for reference)

| gnetId | Dashboard | Folder |
|--------|-----------|--------|
| 1860 | Node Exporter Full | Kubernetes |
| 15757 | Kubernetes / Compute Resources / Cluster | Kubernetes |
| 15758 | Kubernetes / Compute Resources / Namespace | Kubernetes |
| 15759 | Kubernetes / Compute Resources / Node | Kubernetes |
| 15760 | Kubernetes / Compute Resources / Pod | Kubernetes |

These cover cluster-level health well. No changes needed.

## Test plan

- [ ] ArgoCD syncs grafana app after merge
- [ ] Grafana pod restarts (Recreate strategy) and init container downloads gnetId 10347
- [ ] `Proxmox` folder appears in Grafana sidebar
- [ ] pve-overview dashboard shows 3 PVE nodes (router/minipc/nas) with CPU/mem data
- [ ] Existing Kubernetes dashboards unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in Grafana provisioning for Proxmox dashboards.
  * Included a new Proxmox overview dashboard with Mimir as the data source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->